### PR TITLE
Implement launching browser

### DIFF
--- a/shiny/app.py
+++ b/shiny/app.py
@@ -1,7 +1,9 @@
 __all__ = ("App",)
 
 import contextlib
+import os
 from typing import Any, List, Optional, Union, Dict, Callable, cast
+import webbrowser
 
 from htmltools import Tag, TagList, HTMLDocument, HTMLDependency, RenderedHTML
 
@@ -63,6 +65,7 @@ class App:
 
     @contextlib.asynccontextmanager
     async def lifespan(self, app: starlette.applications.Starlette):
+        maybe_launch_browser()
         unreg = reactcore.on_flushed(self._on_reactive_flushed, once=False)
         try:
             yield
@@ -216,3 +219,13 @@ class App:
 def _render_page(ui: Union[Tag, TagList], lib_prefix: str) -> RenderedHTML:
     doc = HTMLDocument(TagList(jquery_deps(), shiny_deps(), ui))
     return doc.render(lib_prefix=lib_prefix)
+
+
+def maybe_launch_browser() -> bool:
+    url = os.environ["SHINY_LAUNCH_BROWSER"]
+
+    if url and (url.startswith("http://") or url.startswith("https://")):
+        webbrowser.open(os.environ["SHINY_LAUNCH_BROWSER"])
+        return True
+
+    return False


### PR DESCRIPTION
This works, but I can't get it to reuse a browser window (my [comment here](https://github.com/rstudio/prism/pull/59#issuecomment-1030254115) was incorrect--I don't know why I thought that worked... unless maybe I was on Linux when I tried it last?).

I really don't like the way this works now, if you hit Save on a .py file 5 times, now you've got 5 new browser tabs. I think we need to put a little more smarts into the browser. Maybe shiny.js can detect this kind of termination somehow, and after disconnect, repeatedly try to establish a websocket connection again (with exponential backoff, maybe). If a connection succeeds, then `window.location.reload()`.