### PR TITLE
Change order of types

### DIFF
--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -406,7 +406,7 @@ def Calc(
     ~shiny.event
     """
 
-    def create_calc(fn: Union[CalcFunctionAsync[T], CalcFunction[T]]) -> Calc_[T]:
+    def create_calc(fn: Union[CalcFunction[T], CalcFunctionAsync[T]]) -> Calc_[T]:
         if _utils.is_async_callable(fn):
             return CalcAsync_(fn, session=session)
         else:


### PR DESCRIPTION
With pyright 1.1.266, we started seeing new errors like this:

```
  /home/runner/work/py-shiny/py-shiny/shiny/reactive/_reactives.py:411:20 - error: Expression of type "CalcAsync_[Awaitable[T@Calc] | T@Calc]" cannot be assigned to return type "Calc_[T@Calc]"
    TypeVar "T@Calc_" is invariant
      Type "Awaitable[T@Calc] | T@Calc" cannot be assigned to type "T@Calc" (reportGeneralTypeIssues)
```

This is due to a bug (I think) in pyright: https://github.com/microsoft/pyright/issues/3813

This PR changes the order of types in the `Union` to avoid the false positive.