### PR TITLE
Delegate shinylive deployment to code in shinylive

### DIFF
--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -389,11 +389,28 @@ After writing the output files, you can serve them locally with the following co
     help='Subdir in which to put the app. Use "." to put the app at the top level of the destdir. If there are multiple APPDIRs, there must be one --subdir for each APPDIR.',
     show_default=True,
 )
+@click.option(
+    "--full-shinylive",
+    is_flag=True,
+    default=False,
+    help="Include the full Shinylive bundle, including all Pyodide packages. Normally, only the packages needed to run the application are included.",
+    show_default=True,
+)
 def static(
-    appdir: Tuple[str], destdir: str, overwrite: bool, subdir: Tuple[str], verbose: bool
+    appdir: Tuple[str],
+    destdir: str,
+    overwrite: bool,
+    subdir: Tuple[str],
+    verbose: bool,
+    full_shinylive: bool,
 ) -> None:
     _static.deploy_static(
-        appdir, destdir, overwrite=overwrite, subdir=subdir, verbose=verbose
+        appdir,
+        destdir,
+        overwrite=overwrite,
+        subdir=subdir,
+        verbose=verbose,
+        full_shinylive=full_shinylive,
     )
 
 

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -7,7 +7,7 @@ import shutil
 import sys
 import types
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import click
 import uvicorn
@@ -352,7 +352,7 @@ def create(appdir: str) -> None:
 @main.command(
     help="""Turn a Shiny app into a statically deployable bundle.
 
-APPDIR is the directory containing the Shiny application.
+APPDIR is one or more directories containing the Shiny application.
 
 DESTDIR is the destination directory where the output files will be written to. This
 directory can be deployed as a static web site.
@@ -364,7 +364,7 @@ After writing the output files, you can serve them locally with the following co
     python3 -m http.server --directory DESTDIR 8008
 """
 )
-@click.argument("appdir", type=str)
+@click.argument("appdir", type=str, nargs=-1)
 @click.argument("destdir", type=str)
 @click.option(
     "--overwrite",
@@ -382,13 +382,15 @@ After writing the output files, you can serve them locally with the following co
 )
 @click.option(
     "--subdir",
+    "-s",
     type=str,
-    default=None,
-    help="Subdir in which to put the app.",
+    default=(),
+    multiple=True,
+    help='Subdir in which to put the app. Use "." to put the app at the top level of the destdir. If there are multiple APPDIRs, there must be one --subdir for each APPDIR.',
     show_default=True,
 )
 def static(
-    appdir: str, destdir: str, overwrite: bool, subdir: str, verbose: bool
+    appdir: Tuple[str], destdir: str, overwrite: bool, subdir: Tuple[str], verbose: bool
 ) -> None:
     _static.deploy_static(
         appdir, destdir, overwrite=overwrite, subdir=subdir, verbose=verbose

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -7,7 +7,7 @@ import shutil
 import sys
 import types
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import click
 import uvicorn

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -352,7 +352,7 @@ def create(appdir: str) -> None:
 @main.command(
     help="""Turn a Shiny app into a statically deployable bundle.
 
-APPDIR is one or more directories containing the Shiny application.
+APPDIR is the directory containing the Shiny application.
 
 DESTDIR is the destination directory where the output files will be written to. This
 directory can be deployed as a static web site.
@@ -364,15 +364,8 @@ After writing the output files, you can serve them locally with the following co
     python3 -m http.server --directory DESTDIR 8008
 """
 )
-@click.argument("appdir", type=str, nargs=-1)
+@click.argument("appdir", type=str)
 @click.argument("destdir", type=str)
-@click.option(
-    "--overwrite",
-    is_flag=True,
-    default=False,
-    help="Overwrite existing files in the destination directory.",
-    show_default=True,
-)
 @click.option(
     "--verbose",
     is_flag=True,
@@ -382,32 +375,28 @@ After writing the output files, you can serve them locally with the following co
 )
 @click.option(
     "--subdir",
-    "-s",
     type=str,
-    default=(),
-    multiple=True,
-    help='Subdir in which to put the app. Use "." to put the app at the top level of the destdir. If there are multiple APPDIRs, there must be one --subdir for each APPDIR.',
+    default=None,
+    help="Subdir in which to put the app.",
     show_default=True,
 )
 @click.option(
     "--full-shinylive",
     is_flag=True,
     default=False,
-    help="Include the full Shinylive bundle, including all Pyodide packages. Normally, only the packages needed to run the application are included.",
+    help="Include the full Shinylive bundle, including all Pyodide packages. Without this flag, only the packages needed to run the application are included.",
     show_default=True,
 )
 def static(
-    appdir: Tuple[str, ...],
+    appdir: str,
     destdir: str,
-    overwrite: bool,
-    subdir: Tuple[str, ...],
+    subdir: Union[str, None],
     verbose: bool,
     full_shinylive: bool,
 ) -> None:
     _static.deploy_static(
         appdir,
         destdir,
-        overwrite=overwrite,
         subdir=subdir,
         verbose=verbose,
         full_shinylive=full_shinylive,

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -397,10 +397,10 @@ After writing the output files, you can serve them locally with the following co
     show_default=True,
 )
 def static(
-    appdir: Tuple[str],
+    appdir: Tuple[str, ...],
     destdir: str,
     overwrite: bool,
-    subdir: Tuple[str],
+    subdir: Tuple[str, ...],
     verbose: bool,
     full_shinylive: bool,
 ) -> None:

--- a/shiny/_static.py
+++ b/shiny/_static.py
@@ -22,7 +22,7 @@ class FileContentJson(TypedDict):
 
 
 def deploy_static(
-    appdirs: Tuple[Union[str, Path]],
+    appdirs: Tuple[Union[str, Path], ...],
     destdir: Union[str, Path],
     *,
     overwrite: bool = False,

--- a/shiny/_static.py
+++ b/shiny/_static.py
@@ -4,7 +4,7 @@ import re
 import shutil
 import sys
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal, TypedDict
@@ -22,29 +22,17 @@ class FileContentJson(TypedDict):
 
 
 def deploy_static(
-    appdir: Union[str, Path],
+    appdirs: Tuple[Union[str, Path]],
     destdir: Union[str, Path],
     *,
     overwrite: bool = False,
-    subdir: Union[str, Path, None] = None,
+    subdir: Tuple[Union[str, Path], ...] = (),
     version: str = _SHINYLIVE_DEFAULT_VERSION,
     verbose: bool = False,
 ) -> None:
     """
     Create a statically deployable distribution with a Shiny app.
     """
-
-    appdir = Path(appdir)
-    destdir = Path(destdir)
-
-    if not (appdir / "app.py").exists():
-        raise ValueError(f"Directory {appdir} must contain a file named app.py.")
-
-    if subdir is None:
-        subdir = ""
-    subdir = Path(subdir)
-    if subdir.is_absolute():
-        raise ValueError("subdir must be a relative path")
 
     shinylive_bundle_dir = _ensure_shinylive_local(version=version)
 
@@ -62,7 +50,7 @@ def deploy_static(
 
     # Call out to shinylive module to do deployment.
     shinylive.deploy(
-        appdir, destdir, overwrite=overwrite, subdir=subdir, verbose=verbose
+        appdirs, destdir, overwrite=overwrite, subdirs=subdir, verbose=verbose
     )
 
 

--- a/shiny/_static.py
+++ b/shiny/_static.py
@@ -4,7 +4,7 @@ import re
 import shutil
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal, TypedDict
@@ -22,11 +22,10 @@ class FileContentJson(TypedDict):
 
 
 def deploy_static(
-    appdirs: Tuple[Union[str, Path], ...],
+    appdir: Union[str, Path],
     destdir: Union[str, Path],
     *,
-    overwrite: bool = False,
-    subdir: Tuple[Union[str, Path], ...] = (),
+    subdir: Union[str, Path, None] = None,
     version: str = _SHINYLIVE_DEFAULT_VERSION,
     verbose: bool = False,
     full_shinylive: bool = False,
@@ -51,10 +50,9 @@ def deploy_static(
 
     # Call out to shinylive module to do deployment.
     shinylive.deploy(
-        appdirs,
+        appdir,
         destdir,
-        overwrite=overwrite,
-        subdirs=subdir,
+        subdir=subdir,
         verbose=verbose,
         full_shinylive=full_shinylive,
     )

--- a/shiny/_static.py
+++ b/shiny/_static.py
@@ -29,6 +29,7 @@ def deploy_static(
     subdir: Tuple[Union[str, Path], ...] = (),
     version: str = _SHINYLIVE_DEFAULT_VERSION,
     verbose: bool = False,
+    full_shinylive: bool = False,
 ) -> None:
     """
     Create a statically deployable distribution with a Shiny app.
@@ -50,7 +51,12 @@ def deploy_static(
 
     # Call out to shinylive module to do deployment.
     shinylive.deploy(
-        appdirs, destdir, overwrite=overwrite, subdirs=subdir, verbose=verbose
+        appdirs,
+        destdir,
+        overwrite=overwrite,
+        subdirs=subdir,
+        verbose=verbose,
+        full_shinylive=full_shinylive,
     )
 
 


### PR DESCRIPTION
This PR makes it so that when `shiny static` is called, it runs code provided by the shinylive bundle. This makes it so that shinylive can make changes to how it does deployment, without having to synchronize it with the shiny package.

Along with https://github.com/rstudio/py-shinylive/pull/14, it also makes the following possible:

*****

Multiple applications can be deployed in one command, with:

```py
shiny static app1 site --subdir a1
shiny static app2 site --subdir a2
shiny static app3 site --subdir a3
```

This will create the following directory structure:

```
site
├── a1
│   ├── app.json
│   ├── edit
│   │   └── index.html
│   └── index.html
├── a2
│   ├── app.json
│   ├── edit
│   │   └── index.html
│   └── index.html
├── a3
│   ├── app.json
│   ├── edit
│   │   └── index.html
│   └── index.html
├── serviceworker.js
└── shinylive     # Other JS stuff in here, including pyodide
```

All of the deployed apps share the same shinylive resources.

Note that if you want one to be deployed to the top level, it can be done by just not using `--subdir`:

```py
shiny static app1 site
shiny static app2 site --subdir a2
```

```
site
├── app.json   # Top level application, from source dir app1/
├── edit
│   └── index.html
├── index.html
├── a2
│   ├── app.json
│   ├── edit
│   │   └── index.html
│   └── index.html
├── serviceworker.js
└── shinylive
```

*****

`shiny static` now by default only includes packages needed to run the deployed application(s). Previously, a deployment would be about 200MB because it included all of the packages from Pyodide, as well as a few other shiny-related packages. With the change in rstudio/py-shinylive#14, a minimal shinylive app deployment is now about 27MB.

If deployed this way, then when a user goes to the `/edit/` page and makes changes or runs code in the terminal, they will not be able to load any extra packages that normally are part of the distribution (they will be able to load packages from PyPI, but as always, these packages must not contained any compiled code).

In order to include the full Shinylive distribution, the option `--full-shinylive` can be used.