### PR TITLE
Plot using pyplot global figure

### DIFF
--- a/examples/global_pyplot/app.py
+++ b/examples/global_pyplot/app.py
@@ -1,0 +1,18 @@
+import matplotlib.pyplot as plt
+from shiny import App, Inputs, Outputs, Session, render, ui
+
+app_ui = ui.page_fluid(
+    ui.input_checkbox("render", "Render", value=True),
+    ui.output_plot("mpl"),
+)
+
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @output
+    @render.plot
+    def mpl():
+        if input.render():
+            plt.hist([1, 1, 2, 3, 5])
+
+
+app = App(app_ui, server)

--- a/examples/global_pyplot/app.py
+++ b/examples/global_pyplot/app.py
@@ -1,9 +1,18 @@
+from shiny import Inputs, Outputs, Session, App, render, ui
 import matplotlib.pyplot as plt
-from shiny import App, Inputs, Outputs, Session, render, ui
 
 app_ui = ui.page_fluid(
     ui.input_checkbox("render", "Render", value=True),
+    ui.panel_conditional(
+        "input.render",
+        ui.tags.h5("A plot should appear immediately below this text."),
+    ),
     ui.output_plot("mpl"),
+    ui.panel_conditional(
+        "input.render",
+        ui.tags.h5("An error message should appear immediately below this text."),
+    ),
+    ui.output_plot("mpl_bad"),
 )
 
 
@@ -11,6 +20,12 @@ def server(input: Inputs, output: Outputs, session: Session):
     @output
     @render.plot
     def mpl():
+        if input.render():
+            plt.hist([1, 1, 2, 3, 5])
+
+    @output
+    @render.plot
+    async def mpl_bad():
         if input.render():
             plt.hist([1, 1, 2, 3, 5])
 

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -230,8 +230,7 @@ class RenderPlot(RenderFunction[object, Union[ImgData, None]]):
 
         x = await self._fn()
 
-        if x is None:
-            return None
+        # Note that x might be None; it could be a matplotlib.pyplot
 
         # Try each type of renderer in turn. The reason we do it this way is to avoid
         # importing modules that aren't already loaded. That could slow things down, or
@@ -264,6 +263,9 @@ class RenderPlot(RenderFunction[object, Union[ImgData, None]]):
             )
             if result != "TYPE_MISMATCH":
                 return result
+
+        if x is None:
+            return None
 
         raise Exception(
             f"@render.plot doesn't know to render objects of type '{str(type(x))}'. "

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -197,6 +197,7 @@ RenderPlotFuncAsync = Callable[[], Awaitable[object]]
 
 class RenderPlot(RenderFunction[object, Union[ImgData, None]]):
     _ppi: float = 96
+    _is_userfn_async = False
 
     def __init__(
         self, fn: RenderPlotFunc, *, alt: Optional[str] = None, **kwargs: object
@@ -255,7 +256,14 @@ class RenderPlot(RenderFunction[object, Union[ImgData, None]]):
 
         if "matplotlib" in sys.modules:
             ok, result = try_render_matplotlib(
-                x, width, height, pixelratio, self._ppi, **self._kwargs
+                x,
+                width,
+                height,
+                pixelratio=pixelratio,
+                ppi=self._ppi,
+                allow_global=not self._is_userfn_async,
+                alt=self._alt,
+                **self._kwargs,
             )
             if ok:
                 return result
@@ -280,6 +288,8 @@ class RenderPlot(RenderFunction[object, Union[ImgData, None]]):
 
 
 class RenderPlotAsync(RenderPlot, RenderFunctionAsync[object, Union[ImgData, None]]):
+    _is_userfn_async = True
+
     def __init__(
         self, fn: RenderPlotFuncAsync, alt: Optional[str] = None, **kwargs: Any
     ) -> None:

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -348,6 +348,12 @@ def plot(
            :class:`matplotlib.figure.Figure` instance.
         5. A :class:`PIL.Image.Image` instance.
 
+    It's also possible to use the `matplotlib.pyplot` interface; in that case, your
+    function should just call pyplot functions and not return anything. (Note that if
+    the decorated function is async, then it's not safe to use pyplot. Shiny will detect
+    this case and throw an error asking you to use matplotlib's object-oriented
+    interface instead.)
+
     Tip
     ----
     This decorator should be applied **before** the ``@output`` decorator. Also, the

--- a/shiny/render/_try_render_plot.py
+++ b/shiny/render/_try_render_plot.py
@@ -144,6 +144,11 @@ def get_matplotlib_figure(x: object) -> Union[MplFigure, None]:
     from matplotlib.animation import (  # pyright: reportMissingTypeStubs=false,reportUnknownVariableType=false
         Animation,
     )
+    from matplotlib.pyplot import gcf, get_fignums
+
+    # pyplot global figure was used
+    if x is None and len(get_fignums()) > 0:
+        return cast(MplFigure, gcf())
 
     if isinstance(x, Figure):
         return cast(MplFigure, x)

--- a/shiny/render/_try_render_plot.py
+++ b/shiny/render/_try_render_plot.py
@@ -147,7 +147,7 @@ def get_matplotlib_figure(x: object, allow_global: bool) -> Union[MplFigure, Non
     #   case, maybe we ignore gcf(), maybe both.
     if (
         x is None and len(plt.get_fignums()) > 0
-    ):  # pyright: reportUnknownArgumentType=false
+    ):  # pyright: reportUnknownArgumentType=false, reportUnknownMemberType=false
         if allow_global:
             return cast(MplFigure, plt.gcf())
         else:
@@ -185,7 +185,7 @@ def get_matplotlib_figure(x: object, allow_global: bool) -> Union[MplFigure, Non
     # If they all refer to the same figure, then it seems reasonable to use it
     # https://docs.xarray.dev/en/latest/user-guide/plotting.html#dimension-along-y-axis
     if isinstance(x, (list, tuple)):
-        figs = [get_matplotlib_figure(y) for y in cast(List[Any], x)]
+        figs = [get_matplotlib_figure(y, allow_global) for y in cast(List[Any], x)]
         if len(set(figs)) == 1:
             return figs[0]
 


### PR DESCRIPTION
Fixes #312.

Turns out it is pretty easy to get at the pyplot global figure. However, this is a bad idea if you are using async, or multiple threads (we don't currently allow this but we might later on).

### TODO

- [x] Throw error if global pyplot figure is used and user function is async

### QA notes

I added an example at `examples/global_pyplot/app.py`, will write tests against it when we have that infrastructure ready.