### PR TITLE
Add --launch-browser option to shiny run, and random port

### DIFF
--- a/shiny/_launchbrowser.py
+++ b/shiny/_launchbrowser.py
@@ -27,6 +27,10 @@ class LaunchBrowserHandler(logging.Handler):
             self._launched = True
             port = os.environ["SHINY_PORT"]
             if not port.isnumeric():
+                print(
+                    "SHINY_PORT environment variable not set or unusable; "
+                    "--launch-browser will be ignored"
+                )
                 # For some reason the shiny port isn't set correctly!?
                 return
             host = os.environ["SHINY_HOST"]

--- a/shiny/_launchbrowser.py
+++ b/shiny/_launchbrowser.py
@@ -2,6 +2,8 @@ import logging
 import os
 import webbrowser
 
+from ._hostenv import get_proxy_url
+
 
 class LaunchBrowserHandler(logging.Handler):
     """Uvicorn log reader, detects successful app startup so we can launch a browser.
@@ -34,4 +36,5 @@ class LaunchBrowserHandler(logging.Handler):
                 # For some reason the shiny port isn't set correctly!?
                 return
             host = os.environ["SHINY_HOST"]
-            webbrowser.open(f"http://{host}:{port}/", 1)
+            url = get_proxy_url(f"http://{host}:{port}/")
+            webbrowser.open(url, 1)

--- a/shiny/_launchbrowser.py
+++ b/shiny/_launchbrowser.py
@@ -1,0 +1,33 @@
+import logging
+import os
+import webbrowser
+
+
+class LaunchBrowserHandler(logging.Handler):
+    """Uvicorn log reader, detects successful app startup so we can launch a browser.
+
+    This class is ONLY used when reload mode is turned off; in the case of reload, the
+    launching of the browser must be tightly coupled to the HotReloadHandler as that is
+    the only way to ensure the browser is only launched at startup, not on every reload.
+    """
+
+    def __init__(self):
+        logging.Handler.__init__(self)
+        self._launched = False
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if self._launched:
+            # Ensure that we never launch a browser window twice. In non-reload
+            # scenarios it probably would never happen anyway, as we're unlikely to get
+            # "Application startup complete." in the logs more than once, but just in
+            # case someone does choose to log that string...
+            return
+
+        if "Application startup complete." in record.getMessage():
+            self._launched = True
+            port = os.environ["SHINY_PORT"]
+            if not port.isnumeric():
+                # For some reason the shiny port isn't set correctly!?
+                return
+            host = os.environ["SHINY_HOST"]
+            webbrowser.open(f"http://{host}:{port}/", 1)

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -210,15 +210,14 @@ def run_app(
         run_app("myapp:my_app", app_dir="..")
     """
 
-    # TODO: If port is 0, randomize
+    # If port is 0, randomize
     if port == 0:
         port = _utils.random_port(host=host)
+        # If autoreload port is calculated relative to
         if reload and (
-            autoreload_port.startswith("+")
-            or autoreload_port.startswith("-")
-            or int(autoreload_port) == 0
+            autoreload_port.startswith("+") or autoreload_port.startswith("-")
         ):
-            autoreload_port = str(_utils.random_port(host=host))
+            autoreload_port = "0"
 
     os.environ["SHINY_HOST"] = host
     os.environ["SHINY_PORT"] = str(port)
@@ -243,11 +242,15 @@ def run_app(
                 "Error: Couldn't understand the provided value for --autoreload-port\n"
             )
             exit(1)
+        autoreload_port = str(_utils.random_port(host=host))
         autoreload_port_num = int(m.group(2))
         if m.group(1) == "+":
             autoreload_port_num += port
         elif m.group(1) == "-":
             autoreload_port_num = port - autoreload_port_num
+
+        if autoreload_port_num == 0:
+            autoreload_port_num = _utils.random_port(host=host)
 
         if autoreload_port_num == port:
             sys.stderr.write(

--- a/shiny/_utils.py
+++ b/shiny/_utils.py
@@ -7,6 +7,7 @@ import mimetypes
 import os
 import random
 import secrets
+import socketserver
 import sys
 import tempfile
 from typing import (
@@ -79,6 +80,34 @@ def guess_mime_type(
     if sys.version_info < (3, 8):
         url = os.fspath(url)
     return mimetypes.guess_type(url, strict)[0] or default
+
+
+def random_port(
+    min: int = 1024, max: int = 49151, host: str = "127.0.0.1", n: int = 20
+) -> int:
+    # fmt: off
+    # From https://github.com/rstudio/httpuv/blob/main/R/random_port.R
+    unsafe_ports = [1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 77, 79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 139, 143, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 556, 563, 587, 601, 636, 993, 995, 2049, 3659, 4045, 6000, 6665, 6666, 6667, 6668, 6669, 6697]
+    # fmt: on
+    unusable = set([x for x in unsafe_ports if x >= min and x <= max])
+    while n > 0:
+        if (max - min + 1) <= len(unusable):
+            break
+        port = round(random.random() * (max - min) + min)
+        if port in unusable:
+            continue
+        try:
+            # See if we can successfully bind
+            with socketserver.TCPServer(
+                (host, port), socketserver.BaseRequestHandler, bind_and_activate=False
+            ) as s:
+                s.server_bind()
+                return port
+        except Exception:
+            n -= 1
+            continue
+
+    raise RuntimeError("Failed to find a usable random port")
 
 
 # ==============================================================================
@@ -163,8 +192,7 @@ def run_coro_sync(coro: Awaitable[T]) -> T:
     value. If it does not complete, then it will throw a `RuntimeError`.
 
     What it means to be "in fact synchronous": the coroutine must not yield
-    control to the event loop. A coroutine may have an `await` expression in it,
-    and that may call another function that has an `await`, but the chain will
+    control to the event loop. A coroutine may have an `await` expression in it, and that may call another function that has an `await`, but the chain will
     only yield control if a `yield` statement bubbles through `await`s all the
     way up. For example, `await asyncio.sleep(0)` will have a `yield` which
     bubbles up to the next level. Note that a `yield` in a generator used the

--- a/shiny/_utils.py
+++ b/shiny/_utils.py
@@ -85,6 +85,26 @@ def guess_mime_type(
 def random_port(
     min: int = 1024, max: int = 49151, host: str = "127.0.0.1", n: int = 20
 ) -> int:
+    """Find an open TCP port
+
+    Finds a random available TCP port for listening on, within a specified range
+    of ports. The default range of ports to check is 1024 to 49151, which is the
+    set of TCP User Ports. This function automatically excludes some ports which
+    are considered unsafe by web browsers.
+
+    Parameters
+    ----------
+    min
+        Minimum port number.
+    max
+        Maximum port number, inclusive.
+    host
+        Before returning a port number, ensure that we can successfully bind it on this
+        host.
+    n
+        Number of times to attempt before giving up.
+    """
+
     # fmt: off
     # From https://github.com/rstudio/httpuv/blob/main/R/random_port.R
     unsafe_ports = [1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 77, 79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 139, 143, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 556, 563, 587, 601, 636, 993, 995, 2049, 3659, 4045, 6000, 6665, 6666, 6667, 6668, 6669, 6697]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,6 +140,9 @@ def test_random_port():
     assert random_port(9000, 9000) == 9000
 
     seen: Set[int] = set()
+    # Ensure that 10 unique random ports are eventually generated. If not (e.g. if the
+    # max port number is treated as exclusive instead of inclusive, say) then the while
+    # loop will not exit and the test will timeout.
     while len(seen) < 10:
         seen.add(random_port(9001, 9010))
 


### PR DESCRIPTION
With this PR, you can add `--launch-browser` to the `shiny run` command and it will pop open a web browser on successful launch.

It's also possible to ask Shiny to use a random port by passing `--port 0`. This will be helpful for RStudio Server and other multiuser scenarios.

## Testing notes

* Tested that `shiny run --reload --launch-browser ...` only launches a browser once, not on each autoreload (i.e. saving `app.py` should cause existing browser window to autoreload but NOT for a new browser window to be launched)
* Tested that `shiny run --launch-browser ...` (i.e. without `--reload`) works; this uses a totally different codepath than `--reload`
* Tested that `--port 0` assigns random port numbers every time
* Tested that `--port 0 --reload` keeps the same random port number for each autoreload
* Tested that `--autoreload-port 0` also gives a random port number (do View Source on the app page, and look for `data-ws-url`

Plus: all of the above, on RStudio Server
Plus: all of the above, on VSCode on RSW (`--launch-browser` has no effect)

## Integration notes

This PR was designed to work well with RStudio Server and Workbench, but only on a branch that I'm still developing. Basically, the `--launch-browser` looks for the `BROWSER` environment variable; on my branch, RStudio Server sets this environment variable to a script that causes a new window to be opened by the IDE.