### PR TITLE
Fix panel_conditional behavior in the context of modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `panel_conditional` now works correctly inside of Shiny modules. (Thanks, @gcaligari!) (#336)
 
 ### Other changes
 
@@ -22,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `shiny run` now takes a `--launch-browser` argument that causes the default web browser to be launched after the app is successfully loaded. Also, the `--port` argument now interprets a value of `0` as "listen on a random port". (#329)
 
- 
 ### Other changes
 
 * Updated API document generation with updated paths to work with new version of Shinylive. (#331)

--- a/e2e/module-conditional/app.py
+++ b/e2e/module-conditional/app.py
@@ -1,0 +1,36 @@
+from shiny import Inputs, Outputs, Session, App, ui, module
+
+
+def my_ui(message: str) -> ui.TagList:
+    return ui.TagList(
+        ui.input_checkbox("show", "Show secret message", False),
+        ui.panel_conditional(
+            "input.show",
+            message,
+            id=module.resolve_id("cond_message"),
+        ),
+    )
+
+
+mod_ui = module.ui(my_ui)
+
+
+@module.server
+def mod_server(input: Inputs, output: Outputs, session: Session):
+    ...
+
+
+app_ui = ui.page_fluid(
+    ui.h3("Non-module version"),
+    my_ui("Lorem ipsum dolor sit amet"),
+    ui.hr(),
+    ui.h3("Module version"),
+    mod_ui("mod", "consectetur adipiscing elit"),
+)
+
+
+def server(input: Inputs, output: Outputs, session: Session):
+    mod_server("mod")
+
+
+app = App(app_ui, server)

--- a/e2e/module-conditional/test_module_conditional.py
+++ b/e2e/module-conditional/test_module_conditional.py
@@ -1,0 +1,34 @@
+from playwright.sync_api import Page, expect
+
+from conftest import ShinyAppProc
+from controls import CheckboxInput
+
+
+def test_async_app(page: Page, local_app: ShinyAppProc) -> None:
+    page.goto(local_app.url)
+
+    ## Non-module version
+
+    cb_show = CheckboxInput(page, "show")
+    expect(cb_show.loc).to_be_visible()
+    expect(cb_show.loc).not_to_be_checked()
+
+    loc = page.locator("#cond_message")
+    expect(loc).to_be_hidden()
+
+    cb_show.loc.check()
+    expect(loc).to_be_visible()
+    expect(loc).to_contain_text("Lorem ipsum dolor sit amet")
+
+    ## Module version
+
+    cb_mod_show = CheckboxInput(page, "mod-show")
+    expect(cb_mod_show.loc).to_be_visible()
+    expect(cb_mod_show.loc).not_to_be_checked()
+
+    mod_loc = page.locator("#mod-cond_message")
+    expect(mod_loc).to_be_hidden()
+
+    cb_mod_show.loc.check()
+    expect(mod_loc).to_be_visible()
+    expect(mod_loc).to_contain_text("consectetur adipiscing elit")

--- a/shiny/_namespaces.py
+++ b/shiny/_namespaces.py
@@ -23,6 +23,10 @@ Root: ResolvedId = ResolvedId("")
 Id = Union[str, ResolvedId]
 
 
+def current_namespace() -> ResolvedId:
+    return _current_namespace.get()
+
+
 def resolve_id(id: Id) -> ResolvedId:
     curr_ns = _current_namespace.get()
     return curr_ns(id)

--- a/shiny/module.py
+++ b/shiny/module.py
@@ -1,4 +1,4 @@
-__all__ = ("resolve_id", "ui", "server")
+__all__ = ("current_namespace", "resolve_id", "ui", "server")
 
 import sys
 from typing import Callable, TypeVar
@@ -8,7 +8,7 @@ if sys.version_info < (3, 10):
 else:
     from typing import ParamSpec, Concatenate
 
-from ._namespaces import resolve_id, namespace_context, Id
+from ._namespaces import current_namespace, resolve_id, namespace_context, Id
 from .session import Inputs, Outputs, Session, require_active_session, session_context
 
 P = ParamSpec("P")

--- a/shiny/ui/_bootstrap.py
+++ b/shiny/ui/_bootstrap.py
@@ -293,7 +293,7 @@ def panel_conditional(
     ~shiny.ui.output_ui
     """
 
-    ns_prefix = str(current_namespace())
+    ns_prefix = current_namespace()
 
     if ns_prefix != "":
         ns_prefix += "-"

--- a/shiny/ui/_bootstrap.py
+++ b/shiny/ui/_bootstrap.py
@@ -37,6 +37,7 @@ from htmltools import (
 from .._docstring import add_example
 from ._html_dependencies import jqui_deps
 from ._utils import get_window_title
+from ..module import current_namespace
 
 
 # TODO: make a python version of the layout guide?
@@ -291,9 +292,13 @@ def panel_conditional(
     ~shiny.render.ui
     ~shiny.ui.output_ui
     """
-    # TODO: do we need a shiny::NS() equivalent?
-    ns: Callable[[str], str] = lambda x: x
-    return div(*args, data_display_if=condition, data_ns_prefix=ns(""), **kwargs)
+
+    ns_prefix = str(current_namespace())
+
+    if ns_prefix != "":
+        ns_prefix += "-"
+
+    return div(*args, data_display_if=condition, data_ns_prefix=ns_prefix, **kwargs)
 
 
 @add_example()

--- a/shiny/ui/_bootstrap.py
+++ b/shiny/ui/_bootstrap.py
@@ -13,7 +13,7 @@ __all__ = (
 )
 
 import sys
-from typing import Callable, Optional, Union
+from typing import Optional, Union
 
 from shiny.types import MISSING, MISSING_TYPE
 


### PR DESCRIPTION
Fixes #333 

At the HTML markup level, Shiny's conditional panels take a `data-ns-prefix="{moduleid}-"` attribute that tells Shiny to interpret `input.*` and `output.*` expressions as if they are in the context of the given module ID. The Python code was not populating this attribute correctly, because the conditional panel code was written before the module system existed for Python.

## Testing notes

No tests needed, I think--I've included an e2e test that should cover it.