### PR TITLE
NavSet's `tagify()` method now returns tagified contents

### DIFF
--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -369,7 +369,7 @@ class NavSet:
         nav, content = render_navset(
             *self.args, ul_class=ul_class, id=id, selected=self.selected, context={}
         )
-        return self.layout(nav, content)
+        return self.layout(nav.tagify(), content.tagify())
 
     def layout(self, nav: TagChildArg, content: TagChildArg) -> Union[TagList, Tag]:
         return TagList(nav, self.header, content, self.footer)

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -369,7 +369,7 @@ class NavSet:
         nav, content = render_navset(
             *self.args, ul_class=ul_class, id=id, selected=self.selected, context={}
         )
-        return self.layout(nav.tagify(), content.tagify())
+        return self.layout(nav, content).tagify()
 
     def layout(self, nav: TagChildArg, content: TagChildArg) -> Union[TagList, Tag]:
         return TagList(nav, self.header, content, self.footer)

--- a/tests/test_navs.py
+++ b/tests/test_navs.py
@@ -173,3 +173,27 @@ def test_nav_markup():
           <div class="row">Page footer</div>
         </div>"""
     )
+
+
+def test_nav_tagify():
+    class Foo:
+        def tagify(self):
+            return ui.span()
+
+    x = with_private_seed(ui.navset_tab, ui.nav("a", ui.div(Foo())))
+
+    assert TagList(x).render()["html"] == textwrap.dedent(
+        """\
+        <ul class="nav nav-tabs" data-tabsetid="7311">
+          <li class="nav-item">
+            <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link active" href="#tab-7311-0">a</a>
+          </li>
+        </ul>
+        <div class="tab-content" data-tabsetid="7311">
+          <div class="tab-pane active" role="tabpanel" data-value="a" id="tab-7311-0">
+            <div>
+              <span></span>
+            </div>
+          </div>
+        </div>"""
+    )


### PR DESCRIPTION
Closes #337

Note that this is needed since `TagList`'s `tagify()` method doesn't recursively call `tagify()` (maybe it should, @wch?)

https://github.com/rstudio/py-htmltools/blob/ae298449b10de5a193031d7c72d7216f7611cf5a/htmltools/_core.py#L172-L194