### PR TITLE
Fix API doc examples that depend on local files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Closed #240, #330: Fixed live examples with additional files. (#340)
+
 ### Other changes
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -205,6 +205,8 @@ UI (`output_*()`) and server (``render``)ing functions for generating content se
     render.plot
     ui.output_image
     render.image
+    ui.output_table
+    render.table
     ui.output_text
     ui.output_text_verbatim
     render.text

--- a/docs/sphinxext/pyshinyapp.py
+++ b/docs/sphinxext/pyshinyapp.py
@@ -23,7 +23,6 @@ import os
 import shutil
 import sys
 from os.path import abspath, dirname, join
-from typing import TypedDict
 
 from docutils.nodes import Element, SkipNode
 from docutils.parsers.rst import directives
@@ -32,9 +31,9 @@ from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
 
 if sys.version_info >= (3, 8):
-    from typing import Literal
+    from typing import Literal, TypedDict
 else:
-    from typing_extensions import Literal
+    from typing_extensions import Literal, TypedDict
 
 # This is the same as the FileContentJson type in TypeScript.
 class FileContentJson(TypedDict):

--- a/shiny/examples/file_reader/requirements.txt
+++ b/shiny/examples/file_reader/requirements.txt
@@ -1,0 +1,3 @@
+# Pandas needs Jinja2 for table styling, but it doesn't (yet) load automatically
+# in Pyodide, so we need to explicitly list it here.
+Jinja2

--- a/shiny/examples/output_table/requirements.txt
+++ b/shiny/examples/output_table/requirements.txt
@@ -1,0 +1,3 @@
+# Pandas needs Jinja2 for table styling, but it doesn't (yet) load automatically
+# in Pyodide, so we need to explicitly list it here.
+Jinja2

--- a/shiny/ui/_output.py
+++ b/shiny/ui/_output.py
@@ -153,6 +153,23 @@ def output_text_verbatim(id: str, placeholder: bool = False) -> Tag:
 
 @add_example()
 def output_table(id: str, **kwargs: TagAttrArg) -> Tag:
+    """
+    Create a output container for a table.
+
+    Parameters
+    ----------
+    id
+        An input id.
+    **kwargs
+        Additional attributes to add to the container.
+
+    Returns
+    -------
+
+    See Also
+    -------
+    ~shiny.render.table
+    """
     return tags.div({"class": "shiny-html-output"}, id=resolve_id(id), **kwargs)
 
 


### PR DESCRIPTION
Closes #240 
Closes #330

Also adds `output_table` and `render.table` to the API reference