### PR TITLE
Fixed `_installed_shinylive_versions` and added unit tests

### DIFF
--- a/shiny/_static.py
+++ b/shiny/_static.py
@@ -2,11 +2,11 @@ import os
 import re
 import shutil
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional
 
 
 def remove_shinylive_local(
-    shinylive_dir: Union[str, Path, None] = None,
+    shinylive_dir: Optional[Path] = None,
     version: Optional[str] = None,
 ) -> None:
     """Removes local copy of shinylive.
@@ -25,8 +25,6 @@ def remove_shinylive_local(
     if shinylive_dir is None:
         shinylive_dir = get_default_shinylive_dir()
 
-    shinylive_dir = Path(shinylive_dir)
-
     target_dir = shinylive_dir
     if version is not None:
         target_dir = target_dir / f"shinylive-{version}"
@@ -35,20 +33,19 @@ def remove_shinylive_local(
         shutil.rmtree(target_dir)
 
 
-def get_default_shinylive_dir() -> str:
+def get_default_shinylive_dir() -> Path:
     import appdirs
 
-    return os.path.join(appdirs.user_cache_dir("shiny"), "shinylive")
+    return Path(appdirs.user_cache_dir("shiny")) / "shinylive"
 
 
 def _installed_shinylive_versions(shinylive_dir: Optional[Path] = None) -> List[str]:
     if shinylive_dir is None:
-        shinylive_dir = Path(get_default_shinylive_dir())
+        shinylive_dir = get_default_shinylive_dir()
 
-    shinylive_dir = Path(shinylive_dir)
     if not shinylive_dir.exists():
         return []
-    subdirs = shinylive_dir.iterdir()
+    subdirs = next(os.walk(shinylive_dir))[1]
     subdirs = [re.sub("^shinylive-", "", str(s)) for s in subdirs]
     return subdirs
 

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,0 +1,54 @@
+import os
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+
+from shiny._static import (
+    get_default_shinylive_dir,
+    remove_shinylive_local,
+    _installed_shinylive_versions,
+)
+
+
+@contextmanager
+def run_within_dir(path: Path) -> Generator[None, None, None]:
+    """
+    Utility function to run some code within a directory, and change back to the current directory afterwards.
+    Example usage:
+    ```
+    with run_within_dir(directory):
+        some_code()
+    ```
+    """
+    oldpwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(oldpwd)
+
+
+def test_get_default_shinylive_dir():
+    assert isinstance(get_default_shinylive_dir(), Path)
+
+
+def test_remove_shinylive_local(tmp_path: Path):
+    with run_within_dir(tmp_path):
+        shinylive_path = Path("shinylive")
+        shinylive_path.mkdir()
+        assert os.path.exists(shinylive_path)
+        remove_shinylive_local(shinylive_path)
+        assert not os.path.exists(shinylive_path)
+
+
+def test_installed_shinylive_versions(tmp_path: Path):
+    with run_within_dir(tmp_path):
+        Path("shinylive/shinylive-foo").mkdir(parents=True, exist_ok=True)
+        Path("shinylive/shinylive-bar").mkdir(parents=True, exist_ok=True)
+        Path("shinylive/shinylive-bar/nested_directory").mkdir(
+            parents=True, exist_ok=True
+        )
+
+        versions = _installed_shinylive_versions(shinylive_dir=Path("shinylive"))
+        assert set(versions) == {"foo", "bar"}

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,13 +1,12 @@
 import os
-
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator
 
 from shiny._static import (
+    _installed_shinylive_versions,
     get_default_shinylive_dir,
     remove_shinylive_local,
-    _installed_shinylive_versions,
 )
 
 


### PR DESCRIPTION
Contents of this MR:

- Fixed `_installed_shinylive_versions` which seemed to be broken, since `shinylive_dir.iterdir()` will return the directories including the root, e.g. `shinylive/shinylive-1` and thus the regex `re.sub("^shinylive-", "", str(s))` did not work. 
- Added unit tests to increase code coverage for this file from `32%` to `82%`.
- Fixed typing; the function `remove_shinylive_local` is only ever called with a `Path` as argument, so changed `Union[str, Path, None]` to `Optional[Path]`.