### PR TITLE
Added isort and repurposed `make check` command

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: black and isort
         if: steps.install.outcome == 'success' && (success() || failure())
         run: |
-          make format
+          make check
 
       - name: Build API docs
         if: steps.install.outcome == 'success' && (success() || failure())

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -62,7 +62,17 @@ jobs:
       - name: Type check with pyright
         if: steps.install.outcome == 'success' && (success() || failure())
         run: |
-          make check
+          make pyright
+
+      - name: Lint with flake8
+        if: steps.install.outcome == 'success' && (success() || failure())
+        run: |
+          make lint
+
+      - name: black and isort
+        if: steps.install.outcome == 'success' && (success() || failure())
+        run: |
+          make format
 
       - name: Build API docs
         if: steps.install.outcome == 'success' && (success() || failure())
@@ -70,11 +80,6 @@ jobs:
           SHINYLIVE_SRC: ""
         run: |
           cd docs && make html
-
-      - name: Lint with flake8
-        if: steps.install.outcome == 'success' && (success() || failure())
-        run: |
-          make lint
 
       - name: Run e2e tests
         if: steps.install.outcome == 'success' && (success() || failure())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/ambv/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black
+    rev: "22.8.0"
     hooks:
       - id: black
         language_version: python3

--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,20 @@ clean-test: ## remove test and coverage artifacts
 typings/uvicorn/__init__.pyi:
 	pyright --createstub uvicorn
 
-check: typings/uvicorn/__init__.pyi ## type check with pyright
+pyright: typings/uvicorn/__init__.pyi ## type check with pyright
 	pyright
 
-check-old: typings/uvicorn/__init__.pyi ## type check with pyright
-	pyright --pythonversion=3.7
-
 lint: ## check style with flake8
-	flake8 --show-source --max-line-length=127 shiny tests examples
+	echo "Checking style with flake8."
+	flake8 --show-source shiny tests examples
+
+format:
+	echo "Formatting code with black."
+	black .
+	echo "Sorting imports with isort."
+	isort .
+
+check: pyright lint format
 
 test: ## run tests quickly with the default Python
 	python3 tests/asyncio_prevent.py

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ pyright: typings/uvicorn/__init__.pyi ## type check with pyright
 
 lint: ## check style with flake8
 	echo "Checking style with flake8."
-	flake8 --show-source shiny tests examples
+	flake8 --show-source .
 
 format:
 	echo "Formatting code with black."

--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,17 @@ lint: ## check style with flake8
 	echo "Checking style with flake8."
 	flake8 --show-source .
 
-format:
+format: ## format code with black and isort
 	echo "Formatting code with black."
 	black .
 	echo "Sorting imports with isort."
 	isort .
 
-check: pyright lint format
+check: pyright lint ## check code quality with pyright, flake8, black and isort
+	echo "Checking code with black."
+	black --check .
+	echo "Sorting imports with isort."
+	isort --check-only --diff .
 
 test: ## run tests quickly with the default Python
 	python3 tests/asyncio_prevent.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ pytest-asyncio>=0.17.2
 black>=22.3.0
 flake8>=3.9.2
 flake8-bugbear>=22.6.22
+isort>=5.10.1
 pytest-playwright>=0.3.0
 pre-commit>=2.15.0
 sphinx>=4.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,9 @@ console_scripts =
 # F405: Name may be undefined, or defined from star imports
 # W503: Line break occurred before a binary operator
 ignore = E302, E501, F403, F405, W503
-exclude = docs, .venv
+extend_exclude = docs, .venv, venv, typings, e2e
+
+
 
 [tox:tox]
 envlist = mytestenv

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,3 +95,6 @@ commands =
     # We are currently ONLY using tox for running e2e tests.
     playwright install --with-deps
     pytest {posargs:e2e} --browser webkit --browser firefox --browser chromium --numprocesses auto
+
+[isort]
+profile=black


### PR DESCRIPTION
This MR is a smaller version of my initial MR: https://github.com/rstudio/py-shiny/pull/342

The purpose of the MR is to improve developer experience by not having to run multiple commands locally to verify code formatting. Right now, `make check`, `make lint` and `isort .` need to be run separately, and `black` is called by `pre-commit`. This MR proposes to have `make check` verify all aspects of code quality. Next to that, it proposes to introduce `isort` to improve code quality.

- Add [isort](https://github.com/PyCQA/isort) to sort imports.
- Fix `black` URL in `pre-commit-config.yaml`.
- Fixed issue where `flake8` was configured to include specific directories in the `make lint `command, making the `extend-exclude`  in `setup.cfg` obsolete, but also resulting in `make lint` and `flake8 .` giving potentially different results since they operate on different files. Moved all configuration to `setup.cfg`.
- Repurposed the `make check` command to not only check type hints, but actually perform all code quality checks., while also keeping the separate `make` commands. Adapted the GitHub workflow accordingly.
- Removed the `check-old` command, since it does not seem to be used anymore.

Please note: CI/CD will currently fail because `isort` is not applied to the `.py` files yet!