### PR TITLE
Add --reload-dir command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* `shiny run` now takes zero or more `--reload-dir` arguments that can be used with `--reload` to indicate what directories should be (recursively) monitored for reload. If zero such arguments are passed, then the directory containing the app will be recursively monitored.
 
 ### Bug fixes
 


### PR DESCRIPTION
This is helpful when working on a package that extends Shiny; you can have the Shiny app reload whenever the package changes.

Also warns if `WEB_CONCURRENCY` is set to a value other than "1" (see #335).