### PR TITLE
Fix `shiny run` for Windows absolute paths with drive letter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Closed #240, #330: Fixed live examples with additional files. (#340)
 
+* Fixed `shiny run` handling on Windows of absolute paths with drive letter, as in `shiny run c:/myapp/app.py`. (#370)
+
 ### Other changes
 
 

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -2,6 +2,8 @@ import copy
 import importlib
 import importlib.util
 import os
+import platform
+import re
 import shutil
 import sys
 import types
@@ -301,7 +303,13 @@ def resolve_app(app: str, app_dir: Optional[str]) -> Tuple[str, Optional[str]]:
     #   - directory (look for app:app inside of it)
     # - A module name (look for :app) inside of it
 
-    module, _, attr = app.partition(":")
+    if platform.system() == "Windows" and re.match("^[a-zA-Z]:[/\\\\]", app):
+        # On Windows, need special handling of ':' in some cases, like these:
+        #   shiny run c:/Users/username/Documents/myapp/app.py
+        #   shiny run c:\Users\username\Documents\myapp\app.py
+        module, attr = app, ""
+    else:
+        module, _, attr = app.partition(":")
     if not module:
         raise ImportError("The APP parameter cannot start with ':'.")
     if not attr:


### PR DESCRIPTION
Previously, using `shiny run` with a Windows path with a drive letter would result in an error. For example:

```
C:\Users\Jon\Documents\PyShinyTest>shiny run C:/Users/Jon/Documents/PyShinyTest/app.py
INFO Will watch for changes in these directories: ['C:\Users\Jon\Documents\PyShinyTest']
INFO Uvicorn running on http://127.0.0.1:9092 (Press CTRL+C to quit)
INFO Started reloader process 19484 using StatReload
ERROR: Error loading ASGI app. Could not import module "C".
INFO Stopping reloader process 19484
```

This PR fixes the issue.