### PR TITLE
Fix width parameters for input_select and input_slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* The `width` parameters for `input_select` and `input_slider` now work properly. (Thanks, @bartverweire!)
+
 ### Other changes
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* The `width` parameters for `input_select` and `input_slider` now work properly. (Thanks, @bartverweire!)
+* The `width` parameters for `input_select` and `input_slider` now work properly. (Thanks, @bartverweire!) (#386)
 
 ### Other changes
 

--- a/shiny/ui/_input_select.py
+++ b/shiny/ui/_input_select.py
@@ -5,7 +5,7 @@ __all__ = (
 
 from typing import List, Mapping, Optional, Tuple, Union, cast
 
-from htmltools import Tag, TagChildArg, TagList, div, tags
+from htmltools import Tag, TagChildArg, TagList, css, div, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -175,7 +175,6 @@ def input_select(
                 id=id,
                 class_=None if selectize else "form-select",
                 multiple=multiple,
-                width=width,
                 size=size,
             ),
             (
@@ -188,6 +187,7 @@ def input_select(
             ),
         ),
         class_="form-group shiny-input-container",
+        style=css(width=width),
     )
 
 

--- a/shiny/ui/_input_slider.py
+++ b/shiny/ui/_input_slider.py
@@ -175,7 +175,6 @@ def input_slider(
     props: Dict[str, TagAttrArg] = {
         "class_": "js-range-slider",
         "id": id,
-        "style": css(width=width),
         "data_skin": "shiny",
         # TODO: do we need to worry about scientific notation (i.e., formatNoSci()?)
         "data_min": str(min_num),
@@ -211,6 +210,7 @@ def input_slider(
         tags.input(**props),
         *ionrangeslider_deps(),
         class_="form-group shiny-input-container",
+        style=css(width=width),
     )
 
     if animate is False:


### PR DESCRIPTION
The width was being applied to the control itself, when it really needed to be applied to the input container.

Fixes #385.

![127 0 0 1_51894_](https://user-images.githubusercontent.com/129551/210909493-66eaec4a-20d2-4d62-bd82-3d0d88c8ed0c.png)
