### PR TITLE
Add `Inputs.__contains__` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The `req()` function now returns its first argument (assuming none of its arguments are falsey). This lets you perform validation on expressions as you assign, return, or pass them, without needing to introduce a separate statement just to call `req()`.
 
+* Added `Input.__contains__` method, so that (for example) one could write an expression like `if "x" in inputs`. (#402)
+
 ### Bug fixes
 
 * The `width` parameters for `input_select` and `input_slider` now work properly. (Thanks, @bartverweire!) (#386)

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -873,6 +873,11 @@ class SessionProxy:
 class Inputs:
     """
     A class representing Shiny input values.
+
+    This class provides access to a :class:`~shiny.session.Session`'s input values. The
+    input values are reactive :class:`~shiny.reactive.Values`, and can be accessed with
+    the ``[]`` operator, or with ``.``. For example, if there is an input named ``x``,
+    it can be accessed via ``input["x"]()`` or ``input.x()``.
     """
 
     def __init__(
@@ -915,6 +920,13 @@ class Inputs:
 
     def __delattr__(self, key: str) -> None:
         self.__delitem__(key)
+
+    def __contains__(self, key: str) -> bool:
+        # This looks simple, but does a number of things. By accessing `self[key]`, it
+        # indirectly calls `__getitem__`, which applies a namespace to the key, and
+        # it populates the key if it doesn't exist yet. It then calls `is_set()`, which
+        # creates a reactive dependency, and returns whether the value is set.
+        return self[key].is_set()
 
 
 # ======================================================================================

--- a/tests/test_shinysession.py
+++ b/tests/test_shinysession.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from shiny import *
+from shiny import ui
+from shiny.reactive import Effect, flush, isolate
+from shiny.session import Inputs
+from shiny.types import SilentException
 
 
 def test_require_active_session_error_messages():
@@ -12,3 +15,64 @@ def test_require_active_session_error_messages():
 
     with pytest.raises(RuntimeError, match=r"notification.remove\(\) must be called.*"):
         ui.notification_remove("abc")
+
+
+def test_input_readonly():
+    input = Inputs({})
+
+    with isolate():
+        with pytest.raises(RuntimeError):
+            input.x.set(1)
+
+
+def test_input_nonexistent():
+    # Make sure that if you try to access an input that doesn't exist, it:
+    # - Raises a SilentException
+    # - Appears _not_ to add the item to the Inputs object (even though under the hood,
+    #   it does actually add it)
+    input = Inputs({})
+
+    with isolate():
+        assert "x" not in input
+        with pytest.raises(SilentException):
+            input.x()
+        assert "x" not in input
+        with pytest.raises(SilentException):
+            input.x()
+
+    with isolate():
+        with pytest.raises(SilentException):
+            input.y()
+        assert "y" not in input
+        with pytest.raises(SilentException):
+            input.y()
+        assert "y" not in input
+
+
+@pytest.mark.asyncio
+async def test_input_nonexistent_deps():
+    # Make sure that `"x" in input` causes a reactive dependency to be created.
+    input = Inputs({})
+    result = None
+
+    @Effect()
+    def o1():
+        nonlocal result
+        result = "x" in input
+
+    await flush()
+    assert result is False
+    assert o1._exec_count == 1
+
+    # This should invalidate o1 and cause it to re-execute on the next flush().
+    input.x._set(1)
+    await flush()
+    assert result is True
+    assert o1._exec_count == 2
+
+    # This shouldn't invalidate o1, because it doesn't change the status of x's
+    # existence. (x already exists; this just changes its value.)
+    input.x._set(2)
+    await flush()
+    assert result is True
+    assert o1._exec_count == 2


### PR DESCRIPTION
This adds a method for `Inputs.__contains__`, so that the user can write code like this:

```py
@Effect
def foo():
    if "x" in input:
        ...
```

When `in` is used, Shiny creates a reactive dependency. If `input.x` starts out nonexistent and then later gains a value, then `foo` will be invalidated and re-executed. After that point, `input.x()` _changes_ value, then this will _not_ cause `foo` to invalidate -- the invalidation only occurs when 

When `x` is not yet set from the client, the interface here makes it look like `x` is not in the `Input` object (when `input.x()` and `"x" in input` are called). The underlying implementation actually does add `x` to the `Inputs`'s internal `_map` object, but that is hidden from the user.


Test application:

```py
from shiny import App, Inputs, Outputs, Session, render, ui

app_ui = ui.page_fluid(
    ui.input_checkbox("show_input_txt", "Show text input"),
    ui.output_text_verbatim("txt_status"),
    ui.output_ui("dyn_ui"),
)


def server(input: Inputs, output: Outputs, session: Session):
    @output
    @render.ui
    def dyn_ui():
        if input.show_input_txt():
            return ui.input_text("txt", "Text input:")

    n_exec = 0

    @output
    @render.text
    def txt_status():
        nonlocal n_exec
        n_exec += 1
        return f'"txt" in input: {"txt" in input}\nThis output has executed {n_exec} times.'

app = App(app_ui, server)
```
