### PR TITLE
Switch away from `Union`, `Dict`, and `List`

### DIFF
--- a/shiny/_autoreload.py
+++ b/shiny/_autoreload.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import html
 import http
@@ -6,7 +8,7 @@ import os
 import secrets
 import threading
 import webbrowser
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional
 
 from asgiref.typing import (
     ASGI3Application,
@@ -113,7 +115,7 @@ class InjectAutoreloadMiddleware:
         if scope["type"] != "http" or scope["path"] != "/" or len(self.script) == 0:
             return await self.app(scope, receive, send)
 
-        def mangle_callback(body: bytes) -> Tuple[bytes, bool]:
+        def mangle_callback(body: bytes) -> tuple[bytes, bool]:
             if b"</head>" in body:
                 return (body.replace(b"</head>", self.script, 1), True)
             else:
@@ -200,7 +202,7 @@ async def _coro_main(
     # leads to confusion if all you get is an error.
     async def process_request(
         path: str, request_headers: websockets.datastructures.Headers
-    ) -> Optional[Tuple[http.HTTPStatus, websockets.datastructures.HeadersLike, bytes]]:
+    ) -> Optional[tuple[http.HTTPStatus, websockets.datastructures.HeadersLike, bytes]]:
         # If there's no Upgrade header, it's not a WebSocket request.
         if request_headers.get("Upgrade") is None:
             return (http.HTTPStatus.MOVED_PERMANENTLY, [("Location", app_url)], b"")
@@ -219,7 +221,7 @@ class ResponseMangler:
     """
 
     def __init__(
-        self, send: ASGISendCallable, mangler: Callable[[bytes], Tuple[bytes, bool]]
+        self, send: ASGISendCallable, mangler: Callable[[bytes], tuple[bytes, bool]]
     ) -> None:
         # The underlying ASGI send function
         self._send = send

--- a/shiny/_connection.py
+++ b/shiny/_connection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from abc import ABC, abstractmethod
 from typing import Optional

--- a/shiny/_datastructures.py
+++ b/shiny/_datastructures.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from queue import PriorityQueue
-from typing import Generic, Tuple, TypeVar
+from typing import Generic, TypeVar
 
 T = TypeVar("T")
 
@@ -15,7 +17,7 @@ class PriorityQueueFIFO(Generic[T]):
     def __init__(self) -> None:
         # Using Tuple instead of tuple because in Python 3.8 and earlier, tuple isn't
         # generic
-        self._pq: PriorityQueue[Tuple[int, int, T]] = PriorityQueue()
+        self._pq: PriorityQueue[tuple[int, int, T]] = PriorityQueue()
         self._counter: int = 0
 
     def put(self, priority: int, item: T) -> None:
@@ -31,7 +33,7 @@ class PriorityQueueFIFO(Generic[T]):
         self._pq.put((-priority, self._counter, item))
 
     def get(self) -> T:
-        iteminfo: Tuple[int, int, T] = self._pq.get()
+        iteminfo: tuple[int, int, T] = self._pq.get()
         return iteminfo[2]
 
     def empty(self) -> bool:

--- a/shiny/_docstring.py
+++ b/shiny/_docstring.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import os
 import sys
-from typing import Any, Callable, List, TypeVar
+from typing import Any, Callable, TypeVar
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -67,7 +69,7 @@ def add_example(
         if not os.path.exists(example_file):
             raise ValueError(f"No example for {fn_name}")
 
-        other_files: List[str] = []
+        other_files: list[str] = []
         for f in os.listdir(example_dir):
             abs_f = os.path.join(example_dir, f)
             if os.path.isfile(abs_f) and f != "app.py":
@@ -88,7 +90,7 @@ def add_example(
 
         # When rendering a standalone app, put the code above it (maybe this should be
         # handled by the directive itself?)
-        example_prefix: List[str] = []
+        example_prefix: list[str] = []
         if directive == "shinyapp::":
             example_prefix.extend(
                 [

--- a/shiny/_error.py
+++ b/shiny/_error.py
@@ -1,4 +1,6 @@
-from typing import Dict, cast
+from __future__ import annotations
+
+from typing import cast
 
 import starlette.exceptions as exceptions
 import starlette.responses as responses
@@ -23,7 +25,7 @@ class ErrorMiddleware:
                 e.detail,
                 e.status_code,
                 headers=cast(
-                    Dict[str, str],
+                    "dict[str, str]",
                     e.headers,  # pyright: ignore[reportUnknownMemberType]
                 ),
                 media_type="text/plain",

--- a/shiny/_hostenv.py
+++ b/shiny/_hostenv.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import logging
 import os
 import re
 import typing
 from ipaddress import ip_address
 from subprocess import run
-from typing import Dict, Pattern
+from typing import Pattern
 from urllib.parse import urlparse
 
 
@@ -16,7 +18,7 @@ def is_proxy_env() -> bool:
     return is_workbench()
 
 
-port_cache: Dict[int, str] = {}
+port_cache: dict[int, str] = {}
 
 
 def get_proxy_url(url: str) -> str:

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import importlib
 import importlib.util
@@ -8,7 +10,7 @@ import shutil
 import sys
 import types
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Optional
 
 import click
 import uvicorn
@@ -103,7 +105,7 @@ any of the following will work:
     show_default=True,
 )
 def run(
-    app: Union[str, shiny.App],
+    app: str | shiny.App,
     host: str,
     port: int,
     autoreload_port: int,
@@ -129,7 +131,7 @@ def run(
 
 
 def run_app(
-    app: Union[str, shiny.App] = "app:app",
+    app: str | shiny.App = "app:app",
     host: str = "127.0.0.1",
     port: int = 8000,
     autoreload_port: int = 0,
@@ -212,7 +214,7 @@ def run_app(
     if app_dir:
         app_dir = os.path.realpath(app_dir)
 
-    log_config: Dict[str, Any] = copy.deepcopy(uvicorn.config.LOGGING_CONFIG)
+    log_config: dict[str, Any] = copy.deepcopy(uvicorn.config.LOGGING_CONFIG)
 
     if reload and app_dir is not None:
         reload_dirs = [app_dir]
@@ -251,7 +253,7 @@ def run_app(
 
 
 def setup_hot_reload(
-    log_config: Dict[str, Any],
+    log_config: dict[str, Any],
     autoreload_port: int,
     app_port: int,
     launch_browser: bool,
@@ -269,7 +271,7 @@ def setup_hot_reload(
     _autoreload.start_server(autoreload_port, app_port, launch_browser)
 
 
-def setup_launch_browser(log_config: Dict[str, Any]):
+def setup_launch_browser(log_config: dict[str, Any]):
     log_config["handlers"]["shiny_launch_browser"] = {
         "class": "shiny._launchbrowser.LaunchBrowserHandler",
         "level": "INFO",
@@ -279,7 +281,7 @@ def setup_launch_browser(log_config: Dict[str, Any]):
     log_config["loggers"]["uvicorn.error"]["handlers"].append("shiny_launch_browser")
 
 
-def maybe_setup_rsw_proxying(log_config: Dict[str, Any]) -> None:
+def maybe_setup_rsw_proxying(log_config: dict[str, Any]) -> None:
     # Replace localhost URLs emitted to the log, with proxied URLs
     if _hostenv.is_workbench():
         if "filters" not in log_config:
@@ -294,7 +296,7 @@ def is_file(app: str) -> bool:
     return "/" in app or app.endswith(".py")
 
 
-def resolve_app(app: str, app_dir: Optional[str]) -> Tuple[str, Optional[str]]:
+def resolve_app(app: str, app_dir: Optional[str]) -> tuple[str, Optional[str]]:
     # The `app` parameter can be:
     #
     # - A module:attribute name

--- a/shiny/_namespaces.py
+++ b/shiny/_namespaces.py
@@ -66,7 +66,7 @@ _current_namespace: ContextVar[ResolvedId] = ContextVar(
 
 
 @contextmanager
-def namespace_context(id: Union[Id, None]):
+def namespace_context(id: Id | None):
     namespace = resolve_id(id) if id else Root
     token: Token[ResolvedId] = _current_namespace.set(namespace)
     try:

--- a/shiny/_static.py
+++ b/shiny/_static.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import os
 import re
 import shutil
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 
 def remove_shinylive_local(
@@ -39,7 +41,7 @@ def get_default_shinylive_dir() -> Path:
     return Path(appdirs.user_cache_dir("shiny")) / "shinylive"
 
 
-def _installed_shinylive_versions(shinylive_dir: Optional[Path] = None) -> List[str]:
+def _installed_shinylive_versions(shinylive_dir: Optional[Path] = None) -> list[str]:
     if shinylive_dir is None:
         shinylive_dir = get_default_shinylive_dir()
 

--- a/shiny/_utils.py
+++ b/shiny/_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import functools
@@ -10,18 +12,7 @@ import secrets
 import socketserver
 import sys
 import tempfile
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Awaitable, Callable, Optional, TypeVar, cast
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -46,7 +37,7 @@ def rand_hex(bytes: int) -> str:
     return format_str.format(secrets.randbits(bytes * 8))
 
 
-def drop_none(x: Dict[str, Any]) -> Dict[str, object]:
+def drop_none(x: dict[str, Any]) -> dict[str, object]:
     return {k: v for k, v in x.items() if v is not None}
 
 
@@ -55,10 +46,10 @@ def drop_none(x: Dict[str, Any]) -> Dict[str, object]:
 # won't work for converting "top-level" lists to tuples
 def lists_to_tuples(x: object) -> object:
     if isinstance(x, dict):
-        x = cast(Dict[str, object], x)
+        x = cast(dict[str, object], x)
         return {k: lists_to_tuples(v) for k, v in x.items()}
     elif isinstance(x, list):
-        x = cast(List[object], x)
+        x = cast(list[object], x)
         return tuple(lists_to_tuples(y) for y in x)
     else:
         # TODO: are there other mutable iterators that we want to make read only?
@@ -66,7 +57,7 @@ def lists_to_tuples(x: object) -> object:
 
 
 def guess_mime_type(
-    url: Union[str, "os.PathLike[str]"],
+    url: "str | os.PathLike[str]",
     default: str = "application/octet-stream",
     strict: bool = True,
 ) -> str:
@@ -165,7 +156,7 @@ T = TypeVar("T")
 
 
 def wrap_async(
-    fn: Union[Callable[[], Awaitable[T]], Callable[[], T]]
+    fn: Callable[[], Awaitable[T]] | Callable[[], T]
 ) -> Callable[[], Awaitable[T]]:
     """
     Given a synchronous function that returns T, return an async function that wraps the
@@ -185,7 +176,7 @@ def wrap_async(
 
 
 def is_async_callable(
-    obj: Union[Callable[..., T], Callable[..., Awaitable[T]]]
+    obj: Callable[..., T] | Callable[..., Awaitable[T]]
 ) -> TypeGuard[Callable[..., Awaitable[T]]]:
     """
     Returns True if `obj` is an `async def` function, or if it's an object with a
@@ -310,7 +301,7 @@ def run_coro_hybrid(coro: Awaitable[T]) -> "asyncio.Future[T]":
 # ==============================================================================
 class Callbacks:
     def __init__(self) -> None:
-        self._callbacks: dict[int, Tuple[Callable[[], None], bool]] = {}
+        self._callbacks: dict[int, tuple[Callable[[], None], bool]] = {}
         self._id: int = 0
 
     def register(
@@ -345,7 +336,7 @@ class Callbacks:
 
 class AsyncCallbacks:
     def __init__(self) -> None:
-        self._callbacks: dict[int, Tuple[Callable[[], Awaitable[None]], bool]] = {}
+        self._callbacks: dict[int, tuple[Callable[[], Awaitable[None]], bool]] = {}
         self._id: int = 0
 
     def register(

--- a/shiny/_utils.py
+++ b/shiny/_utils.py
@@ -46,10 +46,10 @@ def drop_none(x: dict[str, Any]) -> dict[str, object]:
 # won't work for converting "top-level" lists to tuples
 def lists_to_tuples(x: object) -> object:
     if isinstance(x, dict):
-        x = cast(dict[str, object], x)
+        x = cast("dict[str, object]", x)
         return {k: lists_to_tuples(v) for k, v in x.items()}
     elif isinstance(x, list):
-        x = cast(list[object], x)
+        x = cast("list[object]", x)
         return tuple(lists_to_tuples(y) for y in x)
     else:
         # TODO: are there other mutable iterators that we want to make read only?

--- a/shiny/http_staticfiles.py
+++ b/shiny/http_staticfiles.py
@@ -9,6 +9,8 @@ nothing we could disclose that an attacker wouldn't already have access to. The 
 not true when running in native Python, we want to be as safe as possible.
 """
 
+from __future__ import annotations
+
 __all__ = (
     "StaticFiles",
     "FileResponse",
@@ -34,7 +36,7 @@ else:
     import os.path
     import pathlib
     import urllib.parse
-    from typing import Iterable, List, MutableMapping, Optional, Tuple, Union
+    from typing import Iterable, MutableMapping, Optional
 
     from starlette.responses import PlainTextResponse
     from starlette.types import Receive, Scope, Send
@@ -45,7 +47,7 @@ else:
         dir: pathlib.Path
         root_path: str
 
-        def __init__(self, *, directory: Union[str, os.PathLike[str]]):
+        def __init__(self, *, directory: str | os.PathLike[str]):
             self.dir = pathlib.Path(os.path.realpath(os.path.normpath(directory)))
 
         async def __call__(self, scope: Scope, receive: Receive, send: Send):
@@ -80,8 +82,8 @@ else:
                 return await FileResponse(final_path)(scope, receive, send)
 
     def _traverse_url_path(
-        dir: pathlib.Path, path_segments: List[str]
-    ) -> Tuple[Optional[pathlib.Path], bool]:
+        dir: pathlib.Path, path_segments: list[str]
+    ) -> tuple[Optional[pathlib.Path], bool]:
         assert len(path_segments) > 0
 
         new_dir = dir
@@ -161,7 +163,7 @@ else:
 
     def _convert_headers(
         headers: Optional[MutableMapping[str, str]], media_type: Optional[str] = None
-    ) -> Iterable[Tuple[bytes, bytes]]:
+    ) -> Iterable[tuple[bytes, bytes]]:
         if headers is None:
             headers = {}
 

--- a/shiny/input_handler.py
+++ b/shiny/input_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 __all__ = ("input_handlers",)
 
 from datetime import date, datetime
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from .session import Session
@@ -15,7 +15,7 @@ from .types import ActionButtonValue
 InputHandlerType = Callable[[Any, str, "Session"], Any]
 
 
-class _InputHandlers(Dict[str, InputHandlerType]):
+class _InputHandlers(dict[str, InputHandlerType]):
     def __init__(self):
         super().__init__()
 
@@ -91,9 +91,7 @@ On the Javascript side, the associated input binding must have a corresponding
 
 
 @input_handlers.add("shiny.date")
-def _(
-    value: Union[str, List[str]], name: str, session: Session
-) -> Union[date, Tuple[date, date]]:
+def _(value: str | list[str], name: str, session: Session) -> date | tuple[date, date]:
     if isinstance(value, str):
         return datetime.strptime(value, "%Y-%m-%d").date()
     return tuple(datetime.strptime(v, "%Y-%m-%d").date() for v in value)
@@ -101,8 +99,8 @@ def _(
 
 @input_handlers.add("shiny.datetime")
 def _(
-    value: Union[int, float, List[int], List[float]], name: str, session: Session
-) -> Union[datetime, Tuple[datetime, datetime]]:
+    value: int | float | list[int] | list[float], name: str, session: Session
+) -> datetime | tuple[datetime, datetime]:
     if isinstance(value, (int, float)):
         return datetime.utcfromtimestamp(value)
     return tuple(datetime.utcfromtimestamp(v) for v in value)

--- a/shiny/input_handler.py
+++ b/shiny/input_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 __all__ = ("input_handlers",)
 
 from datetime import date, datetime
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Dict
 
 if TYPE_CHECKING:
     from .session import Session
@@ -15,7 +15,7 @@ from .types import ActionButtonValue
 InputHandlerType = Callable[[Any, str, "Session"], Any]
 
 
-class _InputHandlers(dict[str, InputHandlerType]):
+class _InputHandlers(Dict[str, InputHandlerType]):
     def __init__(self):
         super().__init__()
 

--- a/shiny/plotutils.py
+++ b/shiny/plotutils.py
@@ -45,7 +45,7 @@ class SeriesFloatXY(TypedDict):
 
 def brushed_points(
     df: pd.DataFrame,
-    brush: Union[BrushInfo, None],
+    brush: BrushInfo | None,
     xvar: Optional[str] = None,
     yvar: Optional[str] = None,
     panelvar1: Optional[str] = None,
@@ -167,7 +167,7 @@ def brushed_points(
 
 def near_points(
     df: pd.DataFrame,
-    coordinfo: Union[CoordInfo, None],
+    coordinfo: CoordInfo | None,
     xvar: Optional[str] = None,
     yvar: Optional[str] = None,
     panelvar1: Optional[str] = None,

--- a/shiny/reactive/_core.py
+++ b/shiny/reactive/_core.py
@@ -1,5 +1,7 @@
 """Low-level reactive components."""
 
+from __future__ import annotations
+
 __all__ = ("isolate", "invalidate_later", "flush", "on_flushed", "get_current_context")
 
 import asyncio
@@ -9,7 +11,7 @@ import traceback
 import typing
 import warnings
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Awaitable, Callable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Awaitable, Callable, Optional, TypeVar
 
 from .. import _utils
 from .._datastructures import PriorityQueueFIFO
@@ -280,7 +282,7 @@ def lock() -> asyncio.Lock:
 
 @add_example()
 def invalidate_later(
-    delay: float, *, session: Union[MISSING_TYPE, "Session", None] = MISSING
+    delay: float, *, session: "MISSING_TYPE | Session | None" = MISSING
 ) -> None:
     """
     Scheduled Invalidation

--- a/shiny/reactive/_poll.py
+++ b/shiny/reactive/_poll.py
@@ -3,16 +3,7 @@ from __future__ import annotations
 import functools
 import os
 from operator import eq
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Awaitable,
-    Callable,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, TypeVar, cast
 
 from .. import _utils, reactive
 from .._docstring import add_example
@@ -28,12 +19,12 @@ T = TypeVar("T")
 
 @add_example()
 def poll(
-    poll_func: Union[Callable[[], Any], Callable[[], Awaitable[Any]]],
+    poll_func: Callable[[], Any] | Callable[[], Awaitable[Any]],
     interval_secs: float = 1,
     *,
     equals: Callable[[Any, Any], bool] = eq,
     priority: int = 0,
-    session: Union[MISSING_TYPE, "Session", None] = MISSING,
+    session: MISSING_TYPE | Session | None = MISSING,
 ) -> Callable[[Callable[[], T]], Callable[[], T]]:
     """
     Create a reactive polling object.
@@ -211,13 +202,14 @@ def poll(
 
 @add_example()
 def file_reader(
-    filepath: Union[
-        str, os.PathLike[str], Callable[[], str], Callable[[], os.PathLike[str]]
-    ],
+    filepath: str
+    | os.PathLike[str]
+    | Callable[[], str]
+    | Callable[[], os.PathLike[str]],
     interval_secs: float = 1,
     *,
     priority: int = 1,
-    session: Union[MISSING_TYPE, "Session", None] = MISSING,
+    session: MISSING_TYPE | Session | None = MISSING,
 ) -> Callable[[Callable[[], T]], Callable[[], T]]:
     """
     Create a reactive file reader.

--- a/shiny/render/_coordmap.py
+++ b/shiny/render/_coordmap.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from matplotlib.transforms import Transform
 
 
-def get_coordmap(fig: Figure) -> Union[Coordmap, None]:
+def get_coordmap(fig: Figure) -> Coordmap | None:
     dims_ar: npt.NDArray[np.double] = fig.get_size_inches() * fig.get_dpi()
     dims: CoordmapDims = {
         "width": dims_ar[0],

--- a/shiny/render/_coordmap.py
+++ b/shiny/render/_coordmap.py
@@ -55,8 +55,8 @@ def get_coordmap_panel(axes: Axes, panel_num: int, height: float) -> CoordmapPan
         axes.get_subplotspec()  # pyright: ignore[reportGeneralTypeIssues]
     )
 
-    domain_xlim = cast(tuple[float, float], axes.get_xlim())
-    domain_ylim = cast(tuple[float, float], axes.get_ylim())
+    domain_xlim = cast("tuple[float, float]", axes.get_xlim())
+    domain_ylim = cast("tuple[float, float]", axes.get_ylim())
 
     # Data coordinates of plotting area
     domain: CoordmapPanelDomain = {

--- a/shiny/render/_coordmap.py
+++ b/shiny/render/_coordmap.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import re
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, List, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ..types import (
     Coordmap,
@@ -35,9 +35,9 @@ def get_coordmap(fig: Figure) -> Coordmap | None:
         "height": dims_ar[1],
     }
 
-    all_axes: List[Axes] = fig.get_axes()  # pyright: ignore[reportUnknownMemberType]
+    all_axes: list[Axes] = fig.get_axes()  # pyright: ignore[reportUnknownMemberType]
 
-    panels: List[CoordmapPanel] = []
+    panels: list[CoordmapPanel] = []
     for i, axes in enumerate(all_axes):
         panel = get_coordmap_panel(axes, i + 1, dims["height"])
         panels.append(panel)
@@ -55,8 +55,8 @@ def get_coordmap_panel(axes: Axes, panel_num: int, height: float) -> CoordmapPan
         axes.get_subplotspec()  # pyright: ignore[reportGeneralTypeIssues]
     )
 
-    domain_xlim = cast(Tuple[float, float], axes.get_xlim())
-    domain_ylim = cast(Tuple[float, float], axes.get_ylim())
+    domain_xlim = cast(tuple[float, float], axes.get_xlim())
+    domain_ylim = cast(tuple[float, float], axes.get_ylim())
 
     # Data coordinates of plotting area
     domain: CoordmapPanelDomain = {
@@ -122,7 +122,7 @@ def get_coordmap_panel(axes: Axes, panel_num: int, height: float) -> CoordmapPan
     }
 
 
-def get_coordmap_plotnine(p: PlotnineFigure, fig: Figure) -> Union[Coordmap, None]:
+def get_coordmap_plotnine(p: PlotnineFigure, fig: Figure) -> Coordmap | None:
     coordmap = get_coordmap(fig)
 
     if coordmap is None:

--- a/shiny/render/_try_render_plot.py
+++ b/shiny/render/_try_render_plot.py
@@ -74,7 +74,7 @@ def try_render_matplotlib(
         matplotlib.pyplot.close(fig)  # pyright: ignore[reportGeneralTypeIssues]
 
 
-def get_matplotlib_figure(x: object, allow_global: bool) -> Union[Figure, None]:
+def get_matplotlib_figure(x: object, allow_global: bool) -> Figure | None:
     import matplotlib.pyplot as plt
     from matplotlib.animation import Animation
     from matplotlib.artist import Artist

--- a/shiny/render/_try_render_plot.py
+++ b/shiny/render/_try_render_plot.py
@@ -112,8 +112,7 @@ def get_matplotlib_figure(x: object, allow_global: bool) -> Union[Figure, None]:
     # should cover most, if not all, of these (it doesn't cover Animation, though).
     # https://matplotlib.org/stable/api/artist_api.html
     if isinstance(x, Artist):
-        # Pyright 1.1.290 seems to fail type narrowing and needs a cast here.
-        return cast(Artist, x).get_figure()  # pyright: reportUnnecessaryCast=false
+        return x.get_figure()
 
     # Some other custom figure-like classes such as seaborn.axisgrid.FacetGrid attach
     # their figure as an attribute

--- a/shiny/render/_try_render_plot.py
+++ b/shiny/render/_try_render_plot.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import base64
 import io
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, cast
 
 from ..types import ImgData, PlotnineFigure
 from ._coordmap import get_coordmap, get_coordmap_plotnine
 
-TryPlotResult = Tuple[bool, Union[ImgData, None]]
+TryPlotResult = Tuple[bool, "ImgData| None"]
 
 
 if TYPE_CHECKING:

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -26,7 +26,6 @@ from typing import (
     Iterable,
     Optional,
     TypeVar,
-    Union,
     cast,
     overload,
 )
@@ -114,7 +113,7 @@ class ClientMessageOther(ClientMessage):
 #
 # (Not currently supported is Awaitable[str], could be added easily enough if needed.)
 DownloadHandler = Callable[
-    [], Union[str, Iterable[Union[bytes, str]], AsyncIterable[Union[bytes, str]]]
+    [], "str | Iterable[bytes | str] | AsyncIterable[bytes | str]"
 ]
 
 DynamicRouteHandler = Callable[[Request], ASGIApp]

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -23,9 +23,7 @@ from typing import (
     AsyncIterable,
     Awaitable,
     Callable,
-    Dict,
     Iterable,
-    List,
     Optional,
     TypeVar,
     Union,
@@ -95,16 +93,16 @@ class ClientMessage(TypedDict):
 
 
 class ClientMessageInit(ClientMessage):
-    data: Dict[str, object]
+    data: dict[str, object]
 
 
 class ClientMessageUpdate(ClientMessage):
-    data: Dict[str, object]
+    data: dict[str, object]
 
 
 # For messages where "method" is something other than "init" or "update".
 class ClientMessageOther(ClientMessage):
-    args: List[object]
+    args: list[object]
     tag: int
 
 
@@ -124,16 +122,16 @@ DynamicRouteHandler = Callable[[Request], ASGIApp]
 
 @dataclasses.dataclass
 class DownloadInfo:
-    filename: Union[Callable[[], str], str, None]
-    content_type: Optional[Union[Callable[[], str], str]]
+    filename: Callable[[], str] | str | None
+    content_type: Optional[Callable[[], str] | str]
     handler: DownloadHandler
     encoding: str
 
 
 class OutBoundMessageQueues(TypedDict):
-    values: List[Dict[str, Any]]
-    input_messages: List[Dict[str, Any]]
-    errors: List[Dict[str, Any]]
+    values: list[dict[str, Any]]
+    input_messages: list[dict[str, Any]]
+    errors: list[dict[str, Any]]
 
 
 def empty_outbound_message_queues() -> OutBoundMessageQueues:
@@ -160,8 +158,8 @@ class Session(object, metaclass=SessionMeta):
     http_conn: HTTPConnection
     input: Inputs
     output: Outputs
-    user: Union[str, None]
-    groups: Union[List[str], None]
+    user: str | None
+    groups: list[str] | None
 
     # ==========================================================================
     # Initialization
@@ -181,8 +179,8 @@ class Session(object, metaclass=SessionMeta):
         self.input: Inputs = Inputs(dict())
         self.output: Outputs = Outputs(self, self.ns, dict(), dict())
 
-        self.user: Union[str, None] = None
-        self.groups: Union[List[str], None] = None
+        self.user: str | None = None
+        self.groups: list[str] | None = None
         credentials_json: str = ""
         if "shiny-server-credentials" in self.http_conn.headers:
             credentials_json = self.http_conn.headers["shiny-server-credentials"]
@@ -202,14 +200,14 @@ class Session(object, metaclass=SessionMeta):
 
         self._outbound_message_queues = empty_outbound_message_queues()
 
-        self._message_handlers: Dict[
+        self._message_handlers: dict[
             str, Callable[..., Awaitable[object]]
         ] = self._create_message_handlers()
         self._file_upload_manager: FileUploadManager = FileUploadManager()
         self._on_ended_callbacks = _utils.Callbacks()
         self._has_run_session_end_tasks: bool = False
-        self._downloads: Dict[str, DownloadInfo] = {}
-        self._dynamic_routes: Dict[str, DynamicRouteHandler] = {}
+        self._downloads: dict[str, DownloadInfo] = {}
+        self._dynamic_routes: dict[str, DynamicRouteHandler] = {}
 
         self._register_session_end_callbacks()
 
@@ -330,7 +328,7 @@ class Session(object, metaclass=SessionMeta):
             finally:
                 self._run_session_end_tasks()
 
-    def _manage_inputs(self, data: Dict[str, object]) -> None:
+    def _manage_inputs(self, data: dict[str, object]) -> None:
         for key, val in data.items():
             keys = key.split(":")
             if len(keys) > 2:
@@ -385,8 +383,8 @@ class Session(object, metaclass=SessionMeta):
         await self._send_message({"response": {"tag": message["tag"], "value": value}})
 
     # This is called during __init__.
-    def _create_message_handlers(self) -> Dict[str, Callable[..., Awaitable[object]]]:
-        async def uploadInit(file_infos: List[FileInfo]) -> Dict[str, object]:
+    def _create_message_handlers(self) -> dict[str, Callable[..., Awaitable[object]]]:
+        async def uploadInit(file_infos: list[FileInfo]) -> dict[str, object]:
             with session_context(self):
                 if self._debug:
                     print("Upload init: " + str(file_infos), flush=True)
@@ -547,7 +545,7 @@ class Session(object, metaclass=SessionMeta):
 
         return HTMLResponse("<h1>Not Found</h1>", 404)
 
-    def send_input_message(self, id: str, message: Dict[str, object]) -> None:
+    def send_input_message(self, id: str, message: dict[str, object]) -> None:
         """
         Send an input message to the session.
 
@@ -564,7 +562,7 @@ class Session(object, metaclass=SessionMeta):
         message
             The message to send.
         """
-        msg: Dict[str, object] = {"id": id, "message": message}
+        msg: dict[str, object] = {"id": id, "message": message}
         self._outbound_message_queues["input_messages"].append(msg)
         self._request_flush()
 
@@ -584,11 +582,11 @@ class Session(object, metaclass=SessionMeta):
         self._send_message_sync({"shiny-remove-ui": msg})
 
     def _send_progress(self, type: str, message: object) -> None:
-        msg: Dict[str, object] = {"progress": {"type": type, "message": message}}
+        msg: dict[str, object] = {"progress": {"type": type, "message": message}}
         self._send_message_sync(msg)
 
     @add_example()
-    async def send_custom_message(self, type: str, message: Dict[str, object]) -> None:
+    async def send_custom_message(self, type: str, message: dict[str, object]) -> None:
         """
         Send a message to the client.
 
@@ -608,7 +606,7 @@ class Session(object, metaclass=SessionMeta):
         """
         await self._send_message({"custom": {type: message}})
 
-    async def _send_message(self, message: Dict[str, object]) -> None:
+    async def _send_message(self, message: dict[str, object]) -> None:
         message_str: str = json.dumps(message) + "\n"
         if self._debug:
             print(
@@ -619,7 +617,7 @@ class Session(object, metaclass=SessionMeta):
             )
         await self._conn.send(json.dumps(message))
 
-    def _send_message_sync(self, message: Dict[str, object]) -> None:
+    def _send_message_sync(self, message: dict[str, object]) -> None:
         """
         Same as _send_message, except that if the message isn't too large and the socket
         isn't too backed up, then the message may be sent synchronously instead of
@@ -683,15 +681,15 @@ class Session(object, metaclass=SessionMeta):
         try:
             omq = self._outbound_message_queues
 
-            values: Dict[str, object] = {}
+            values: dict[str, object] = {}
             for v in omq["values"]:
                 values.update(v)
 
-            errors: Dict[str, object] = {}
+            errors: dict[str, object] = {}
             for err in omq["errors"]:
                 errors.update(err)
 
-            message: Dict[str, object] = {
+            message: dict[str, object] = {
                 "values": values,
                 "inputMessages": omq["input_messages"],
                 "errors": errors,
@@ -735,8 +733,8 @@ class Session(object, metaclass=SessionMeta):
     def download(
         self,
         id: Optional[str] = None,
-        filename: Optional[Union[str, Callable[[], str]]] = None,
-        media_type: Union[None, str, Callable[[], str]] = None,
+        filename: Optional[str | Callable[[], str]] = None,
+        media_type: None | str | Callable[[], str] = None,
         encoding: str = "utf-8",
     ) -> Callable[[DownloadHandler], None]:
         """
@@ -807,7 +805,7 @@ class Session(object, metaclass=SessionMeta):
 
     def _process_ui(self, ui: TagChildArg) -> RenderedDeps:
         res = TagList(ui).render()
-        deps: List[Dict[str, Any]] = []
+        deps: list[dict[str, Any]] = []
         for dep in res["dependencies"]:
             self.app._register_web_dependency(dep)
             dep_dict = dep.as_dict(lib_prefix=self.app.lib_prefix)
@@ -851,7 +849,7 @@ class SessionProxy:
             res = res._parent
         return res
 
-    def send_input_message(self, id: str, message: Dict[str, object]) -> None:
+    def send_input_message(self, id: str, message: dict[str, object]) -> None:
         return self._parent.send_input_message(self.ns(id), message)
 
     def dynamic_route(self, name: str, handler: DynamicRouteHandler) -> str:
@@ -885,7 +883,7 @@ class Inputs:
     """
 
     def __init__(
-        self, values: Dict[str, Value[Any]], ns: Callable[[str], str] = Root
+        self, values: dict[str, Value[Any]], ns: Callable[[str], str] = Root
     ) -> None:
         self._map = values
         self._ns = ns
@@ -945,8 +943,8 @@ class Outputs:
         self,
         session: Session,
         ns: Callable[[str], str],
-        effects: Dict[str, Effect_],
-        suspend_when_hidden: Dict[str, bool],
+        effects: dict[str, Effect_],
+        suspend_when_hidden: dict[str, bool],
     ) -> None:
         self._session = session
         self._ns = ns
@@ -976,7 +974,7 @@ class Outputs:
         suspend_when_hidden: bool = True,
         priority: int = 0,
         name: Optional[str] = None,
-    ) -> Union[None, Callable[[RenderFunction[IT, OT]], None]]:
+    ) -> None | Callable[[RenderFunction[IT, OT]], None]:
         if name is not None:
             from .. import _deprecated
 
@@ -1012,7 +1010,7 @@ class Outputs:
                     {"recalculating": {"name": output_name, "status": "recalculating"}}
                 )
 
-                message: Dict[str, Optional[OT]] = {}
+                message: dict[str, Optional[OT]] = {}
                 try:
                     if _utils.is_async_callable(fn):
                         message[output_name] = await fn()

--- a/shiny/session/_utils.py
+++ b/shiny/session/_utils.py
@@ -7,7 +7,7 @@ __all__ = ("get_current_session", "session_context", "require_active_session")
 import sys
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
 if TYPE_CHECKING:
     from ._session import Session
@@ -21,7 +21,7 @@ else:
 
 
 class RenderedDeps(TypedDict):
-    deps: List[Dict[str, Any]]
+    deps: list[dict[str, Any]]
     html: str
 
 
@@ -65,7 +65,7 @@ def session_context(session: Optional[Session]):
         A :class:`~shiny.Session` instance. If not provided, it is inferred via
         :func:`~shiny.session.get_current_session`.
     """
-    token: Token[Union[Session, None]] = _current_session.set(session)
+    token: Token[Session | None] = _current_session.set(session)
     try:
         with namespace_context(session.ns if session else None):
             yield
@@ -134,14 +134,14 @@ def require_active_session(session: Optional[Session]) -> Session:
 T = TypeVar("T", str, int)
 
 
-def read_thunk(thunk: Union[Callable[[], T], T]) -> T:
+def read_thunk(thunk: Callable[[], T] | T) -> T:
     if callable(thunk):
         return thunk()
     else:
         return thunk
 
 
-def read_thunk_opt(thunk: Optional[Union[Callable[[], T], T]]) -> Optional[T]:
+def read_thunk_opt(thunk: Optional[Callable[[], T] | T]) -> Optional[T]:
     if thunk is None:
         return None
     elif callable(thunk):

--- a/shiny/types.py
+++ b/shiny/types.py
@@ -13,7 +13,7 @@ __all__ = (
 )
 
 import sys
-from typing import TYPE_CHECKING, Any, BinaryIO, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, BinaryIO, Optional
 
 # Even though TypedDict is available in Python 3.8, because it's used with NotRequired,
 # they should both come from the same typing module.
@@ -86,9 +86,9 @@ class ImgData(TypedDict):
 
     src: str
     """The ``src`` attribute of the ``<img>`` tag."""
-    width: NotRequired[Union[str, float]]
+    width: NotRequired[str | float]
     """The ``width`` attribute of the ``<img>`` tag."""
-    height: NotRequired[Union[str, float]]
+    height: NotRequired[str | float]
     """The ``height`` attribute of the ``<img>`` tag."""
     alt: NotRequired[str]
     """The ``alt`` attribute of the ``<img>`` tag."""
@@ -162,8 +162,8 @@ class NavSetArg(Protocol):
     """
 
     def resolve(
-        self, selected: Optional[str], context: Dict[str, Any]
-    ) -> Tuple[TagChildArg, TagChildArg]:
+        self, selected: Optional[str], context: dict[str, Any]
+    ) -> tuple[TagChildArg, TagChildArg]:
         """
         Resolve information provided by the navigation container.
 
@@ -195,11 +195,11 @@ class NavSetArg(Protocol):
 # Use this protocol to avoid needing to maintain working stubs for plotnint. If
 # good stubs ever become available for plotnine, use those instead.
 class PlotnineFigure(Protocol):
-    scales: List[Any]
+    scales: list[Any]
     coordinates: Any
     facet: Any
     layout: Any
-    mapping: Dict[str, str]
+    mapping: dict[str, str]
 
     def save(
         self,
@@ -224,8 +224,8 @@ class CoordmapDims(TypedDict):
 
 
 class CoordmapPanelLog(TypedDict):
-    x: Union[float, None]
-    y: Union[float, None]
+    x: float | None
+    y: float | None
 
 
 class CoordmapPanelDomain(TypedDict):
@@ -243,8 +243,8 @@ class CoordmapPanelRange(TypedDict):
 
 
 class CoordmapPanelMapping(TypedDict):
-    x: Union[str, None]
-    y: Union[str, None]
+    x: str | None
+    y: str | None
     panelvar1: NotRequired[str]
     panelvar2: NotRequired[str]
 
@@ -266,7 +266,7 @@ class CoordmapPanel(TypedDict):
 
 
 class Coordmap(TypedDict):
-    panels: List[CoordmapPanel]
+    panels: list[CoordmapPanel]
     dims: CoordmapDims
 
 

--- a/shiny/ui/_bootstrap.py
+++ b/shiny/ui/_bootstrap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = (
     "row",
     "column",
@@ -13,7 +15,7 @@ __all__ = (
 )
 
 import sys
-from typing import Optional, Union
+from typing import Optional
 
 from shiny.types import MISSING, MISSING_TYPE
 
@@ -293,7 +295,7 @@ def panel_conditional(
 
 @add_example()
 def panel_title(
-    title: Union[str, Tag, TagList], window_title: Union[str, MISSING_TYPE] = MISSING
+    title: str | Tag | TagList, window_title: str | MISSING_TYPE = MISSING
 ) -> TagList:
     """
     Create title(s) for the application.

--- a/shiny/ui/_html_dependencies.py
+++ b/shiny/ui/_html_dependencies.py
@@ -1,11 +1,11 @@
-from typing import List
+from __future__ import annotations
 
 from htmltools import HTML, HTMLDependency
 
 from ..html_dependencies import jquery_deps
 
 
-def bootstrap_deps() -> List[HTMLDependency]:
+def bootstrap_deps() -> list[HTMLDependency]:
     dep = HTMLDependency(
         name="bootstrap",
         version="5.0.1",
@@ -17,7 +17,7 @@ def bootstrap_deps() -> List[HTMLDependency]:
     return deps
 
 
-def ionrangeslider_deps() -> List[HTMLDependency]:
+def ionrangeslider_deps() -> list[HTMLDependency]:
     return [
         HTMLDependency(
             name="ionrangeslider",

--- a/shiny/ui/_input_check_radio.py
+++ b/shiny/ui/_input_check_radio.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 __all__ = (
     "input_checkbox",
     "input_checkbox_group",
     "input_radio_buttons",
 )
 
-from typing import List, Mapping, Optional, Union
+from typing import Mapping, Optional, Union
 
 from htmltools import Tag, TagChildArg, css, div, span, tags
 
@@ -16,7 +18,7 @@ from ._utils import shiny_input_label
 _Choices = Mapping[str, TagChildArg]
 
 # Formats available to the user
-ChoicesArg = Union[List[str], _Choices]
+ChoicesArg = Union["list[str]", _Choices]
 
 
 @add_example()
@@ -142,7 +144,7 @@ def input_checkbox_group(
     label: TagChildArg,
     choices: ChoicesArg,
     *,
-    selected: Optional[Union[str, List[str]]] = None,
+    selected: Optional[str | list[str]] = None,
     inline: bool = False,
     width: Optional[str] = None,
 ) -> Tag:
@@ -276,7 +278,7 @@ def _generate_options(
     id: str,
     type: str,
     choices: ChoicesArg,
-    selected: Optional[Union[str, List[str]]],
+    selected: Optional[str | list[str]],
     inline: bool,
 ) -> Tag:
     choicez = _normalize_choices(choices)

--- a/shiny/ui/_input_date.py
+++ b/shiny/ui/_input_date.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 __all__ = ("input_date", "input_date_range")
 
 import json
 from datetime import date
-from typing import List, Optional, Union
+from typing import Optional
 
 from htmltools import Tag, TagAttrArg, TagChildArg, css, div, span, tags
 
@@ -17,17 +19,17 @@ def input_date(
     id: str,
     label: TagChildArg,
     *,
-    value: Optional[Union[date, str]] = None,
-    min: Optional[Union[date, str]] = None,
-    max: Optional[Union[date, str]] = None,
+    value: Optional[date | str] = None,
+    min: Optional[date | str] = None,
+    max: Optional[date | str] = None,
     format: str = "yyyy-mm-dd",
     startview: str = "month",
     weekstart: int = 0,
     language: str = "en",
     width: Optional[str] = None,
     autoclose: bool = True,
-    datesdisabled: Optional[List[str]] = None,
-    daysofweekdisabled: Optional[List[int]] = None,
+    datesdisabled: Optional[list[str]] = None,
+    daysofweekdisabled: Optional[list[int]] = None,
 ) -> Tag:
     """
     Creates a text input which, when clicked on, brings up a calendar that the user can
@@ -133,10 +135,10 @@ def input_date_range(
     id: str,
     label: TagChildArg,
     *,
-    start: Optional[Union[date, str]] = None,
-    end: Optional[Union[date, str]] = None,
-    min: Optional[Union[date, str]] = None,
-    max: Optional[Union[date, str]] = None,
+    start: Optional[date | str] = None,
+    end: Optional[date | str] = None,
+    min: Optional[date | str] = None,
+    max: Optional[date | str] = None,
     format: str = "yyyy-mm-dd",
     startview: str = "month",
     weekstart: int = 0,
@@ -265,9 +267,9 @@ def input_date_range(
 
 def _date_input_tag(
     id: str,
-    value: Optional[Union[date, str]],
-    min: Optional[Union[date, str]],
-    max: Optional[Union[date, str]],
+    value: Optional[date | str],
+    min: Optional[date | str],
+    max: Optional[date | str],
     format: str,
     startview: str,
     weekstart: int,
@@ -295,7 +297,7 @@ def _date_input_tag(
     )
 
 
-def _as_date_attr(x: Optional[Union[date, str]]) -> Optional[str]:
+def _as_date_attr(x: Optional[date | str]) -> Optional[str]:
     if x is None:
         return None
     if isinstance(x, date):

--- a/shiny/ui/_input_file.py
+++ b/shiny/ui/_input_file.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 __all__ = ("input_file",)
 
 import sys
-from typing import List, Optional, Union
+from typing import Optional
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -21,7 +23,7 @@ def input_file(
     label: TagChildArg,
     *,
     multiple: bool = False,
-    accept: Optional[Union[str, List[str]]] = None,
+    accept: Optional[str | list[str]] = None,
     width: Optional[str] = None,
     button_label: str = "Browse...",
     placeholder: str = "No file selected",

--- a/shiny/ui/_input_select.py
+++ b/shiny/ui/_input_select.py
@@ -1,11 +1,13 @@
 # pyright: reportUnnecessaryComparison=false
 
+from __future__ import annotations
+
 __all__ = (
     "input_select",
     "input_selectize",
 )
 
-from typing import List, Mapping, Optional, Tuple, Union, cast
+from typing import Mapping, Optional, Union, cast
 
 from htmltools import Tag, TagChildArg, TagList, css, div, tags
 
@@ -23,9 +25,9 @@ _SelectChoices = Union[_Choices, _OptGrpChoices]
 # Formats available to the user
 SelectChoicesArg = Union[
     # ["a", "b", "c"]
-    List[str],
+    list[str],
     # ("a", "b", "c")
-    Tuple[str, ...],
+    tuple[str, ...],
     # {"a": "Choice A", "b": tags.i("Choice B")}
     _Choices,
     # optgroup {"Group A": {"a1": "Choice A1", "a2": tags.i("Choice A2")}, "Group B": {}}
@@ -47,7 +49,7 @@ def input_selectize(
     label: TagChildArg,
     choices: SelectChoicesArg,
     *,
-    selected: Optional[Union[str, List[str]]] = None,
+    selected: Optional[str | list[str]] = None,
     multiple: bool = False,
     width: Optional[str] = None,
 ) -> Tag:
@@ -107,7 +109,7 @@ def input_select(
     label: TagChildArg,
     choices: SelectChoicesArg,
     *,
-    selected: Optional[Union[str, List[str]]] = None,
+    selected: Optional[str | list[str]] = None,
     multiple: bool = False,
     selectize: bool = False,
     width: Optional[str] = None,
@@ -203,7 +205,7 @@ def _normalize_choices(x: SelectChoicesArg) -> _SelectChoices:
 
 
 def _render_choices(
-    x: _SelectChoices, selected: Optional[Union[str, List[str]]] = None
+    x: _SelectChoices, selected: Optional[str | list[str]] = None
 ) -> TagList:
     result = TagList()
 

--- a/shiny/ui/_input_select.py
+++ b/shiny/ui/_input_select.py
@@ -25,9 +25,9 @@ _SelectChoices = Union[_Choices, _OptGrpChoices]
 # Formats available to the user
 SelectChoicesArg = Union[
     # ["a", "b", "c"]
-    list[str],
+    "list[str]",
     # ("a", "b", "c")
-    tuple[str, ...],
+    "tuple[str, ...]",
     # {"a": "Choice A", "b": tags.i("Choice B")}
     _Choices,
     # optgroup {"Group A": {"a1": "Choice A1", "a2": tags.i("Choice A2")}, "Group B": {}}

--- a/shiny/ui/_input_slider.py
+++ b/shiny/ui/_input_slider.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = (
     "input_slider",
     "SliderValueArg",
@@ -8,7 +10,7 @@ __all__ = (
 import math
 import sys
 from datetime import date, datetime, timedelta
-from typing import Dict, Iterable, Optional, TypeVar, Union, cast
+from typing import Iterable, Optional, TypeVar, Union, cast
 
 from htmltools import HTML, Tag, TagAttrArg, TagChildArg, css, div, tags
 
@@ -67,11 +69,11 @@ def input_slider(
     label: TagChildArg,
     min: SliderValueArg,
     max: SliderValueArg,
-    value: Union[SliderValueArg, Iterable[SliderValueArg]],
+    value: SliderValueArg | Iterable[SliderValueArg],
     *,
     step: Optional[SliderStepArg] = None,
     ticks: bool = True,
-    animate: Union[bool, AnimationOptions] = False,
+    animate: bool | AnimationOptions = False,
     width: Optional[str] = None,
     sep: str = ",",
     pre: Optional[str] = None,
@@ -172,7 +174,7 @@ def input_slider(
 
     id = resolve_id(id)
 
-    props: Dict[str, TagAttrArg] = {
+    props: dict[str, TagAttrArg] = {
         "class_": "js-range-slider",
         "id": id,
         "data_skin": "shiny",
@@ -245,7 +247,7 @@ def _slider_type(x: SliderValueArg) -> str:
     return "number"
 
 
-def _as_numeric(x: Union[SliderStepArg, datetime, date]) -> float:
+def _as_numeric(x: SliderStepArg | datetime | date) -> float:
     if isinstance(x, timedelta):
         return x.total_seconds() * 1000
     if isinstance(x, datetime):
@@ -255,9 +257,7 @@ def _as_numeric(x: Union[SliderStepArg, datetime, date]) -> float:
     return x
 
 
-def _find_step_size(
-    min: Union[int, float], max: Union[int, float]
-) -> Union[int, float]:
+def _find_step_size(min: int | float, max: int | float) -> int | float:
     # TODO: this is a naive version of shiny::findStepSize() that might be susceptible to
     # rounding errors? https://github.com/rstudio/shiny/pull/1956
     range = max - min
@@ -285,9 +285,9 @@ pause_icon = """<svg viewBox="0 0 448 512" preserveAspectRatio="none" aria-hidde
 </svg>"""
 
 
-def _play_icon() -> Union[Tag, HTML]:
+def _play_icon() -> Tag | HTML:
     return HTML(play_icon)
 
 
-def _pause_icon() -> Union[Tag, HTML]:
+def _pause_icon() -> Tag | HTML:
     return HTML(pause_icon)

--- a/shiny/ui/_input_update.py
+++ b/shiny/ui/_input_update.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = (
     "update_action_button",
     "update_action_link",
@@ -20,7 +22,7 @@ import json
 import re
 import sys
 from datetime import date
-from typing import List, Mapping, Optional, Tuple, Union
+from typing import Mapping, Optional
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
@@ -197,7 +199,7 @@ def update_checkbox_group(
     *,
     label: Optional[str] = None,
     choices: Optional[ChoicesArg] = None,
-    selected: Optional[Union[str, List[str]]] = None,
+    selected: Optional[str | list[str]] = None,
     inline: bool = False,
     session: Optional[Session] = None,
 ) -> None:
@@ -300,7 +302,7 @@ def _update_choice_input(
     type: Literal["checkbox", "radio"],
     label: Optional[str] = None,
     choices: Optional[ChoicesArg] = None,
-    selected: Optional[Union[str, List[str]]] = None,
+    selected: Optional[str | list[str]] = None,
     inline: bool = False,
     session: Optional[Session] = None,
 ) -> None:
@@ -328,9 +330,9 @@ def update_date(
     id: str,
     *,
     label: Optional[str] = None,
-    value: Optional[Union[date, str]] = None,
-    min: Optional[Union[date, str]] = None,
-    max: Optional[Union[date, str]] = None,
+    value: Optional[date | str] = None,
+    min: Optional[date | str] = None,
+    max: Optional[date | str] = None,
     session: Optional[Session] = None,
 ) -> None:
     """
@@ -378,10 +380,10 @@ def update_date_range(
     id: str,
     *,
     label: Optional[str] = None,
-    start: Optional[Union[date, str]] = None,
-    end: Optional[Union[date, str]] = None,
-    min: Optional[Union[date, str]] = None,
-    max: Optional[Union[date, str]] = None,
+    start: Optional[date | str] = None,
+    end: Optional[date | str] = None,
+    min: Optional[date | str] = None,
+    max: Optional[date | str] = None,
     session: Optional[Session] = None,
 ) -> None:
     """
@@ -494,7 +496,7 @@ def update_select(
     *,
     label: Optional[str] = None,
     choices: Optional[SelectChoicesArg] = None,
-    selected: Optional[Union[str, List[str]]] = None,
+    selected: Optional[str | list[str]] = None,
     session: Optional[Session] = None,
 ) -> None:
     """
@@ -563,7 +565,7 @@ def update_selectize(
     *,
     label: Optional[str] = None,
     choices: Optional[SelectChoicesArg] = None,
-    selected: Optional[Union[str, List[str]]] = None,
+    selected: Optional[str | list[str]] = None,
     # TODO: we need the equivalent of base::I()/htmlwidgets::JS() for marking strings as strings to be evaluated
     # options: Optional[Dict[str, str]] = None,
     server: bool = False,
@@ -612,7 +614,7 @@ def update_selectize(
 
     # Transform choices to a list of dicts (this is the form the client wants)
     # [{"label": "Foo", "value": "foo", "optgroup": "foo"}, ...]
-    flat_choices: List[FlatSelectChoice] = []
+    flat_choices: list[FlatSelectChoice] = []
     if choices is not None:
         for k, v in _normalize_choices(choices).items():
             if not isinstance(v, Mapping):
@@ -662,7 +664,7 @@ def update_selectize(
         conjunction = any if qparams.get("conju", "and") == "or" else all
 
         # i.e. searchFields (defaults to ['label'])
-        search_fields: List[str] = json.loads(qparams.get("field", "['label']"))
+        search_fields: list[str] = json.loads(qparams.get("field", "['label']"))
         if len(search_fields) == 0:
             raise ValueError("The selectize.js searchFields option must be non-empty")
 
@@ -684,7 +686,7 @@ def update_selectize(
                 "The selectize.js valueField option must be set to 'value'"
             )
 
-        filtered_choices: List[FlatSelectChoice] = []
+        filtered_choices: list[FlatSelectChoice] = []
         for choice in flat_choices:
             # Short-circuit if we've reached the max number of options
             if (len(filtered_choices) + len(selected_choices)) > max_options:
@@ -729,9 +731,7 @@ def update_slider(
     id: str,
     *,
     label: Optional[str] = None,
-    value: Optional[
-        Union[SliderValueArg, Tuple[SliderValueArg, SliderValueArg]]
-    ] = None,
+    value: Optional[SliderValueArg | tuple[SliderValueArg, SliderValueArg]] = None,
     min: Optional[SliderValueArg] = None,
     max: Optional[SliderValueArg] = None,
     step: Optional[SliderStepArg] = None,

--- a/shiny/ui/_modal.py
+++ b/shiny/ui/_modal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = (
     "modal_button",
     "modal",
@@ -6,7 +8,7 @@ __all__ = (
 )
 
 import sys
-from typing import Optional, Union
+from typing import Optional
 
 from shiny.types import MISSING, MISSING_TYPE
 
@@ -58,7 +60,7 @@ def modal_button(
         type="button",
         data_dismiss="modal",
         data_bs_dismiss="modal",
-        **kwargs
+        **kwargs,
     )
 
 
@@ -66,11 +68,11 @@ def modal_button(
 def modal(
     *args: TagChildArg,
     title: Optional[str] = None,
-    footer: Union[TagChildArg, MISSING_TYPE] = MISSING,
+    footer: TagChildArg | MISSING_TYPE = MISSING,
     size: Literal["m", "s", "l", "xl"] = "m",
     easy_close: bool = False,
     fade: bool = True,
-    **kwargs: TagAttrArg
+    **kwargs: TagAttrArg,
 ) -> Tag:
     """
     Creates the UI for a modal dialog, using Bootstrap's modal class. Modals are

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = (
     "nav",
     "nav_menu",
@@ -15,7 +17,7 @@ __all__ = (
 import copy
 import re
 import sys
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Optional, cast
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -45,8 +47,8 @@ class Nav:
         self.content = content
 
     def resolve(
-        self, selected: Optional[str], context: Dict[str, Any]
-    ) -> Tuple[TagChildArg, TagChildArg]:
+        self, selected: Optional[str], context: dict[str, Any]
+    ) -> tuple[TagChildArg, TagChildArg]:
         # Nothing to do for nav_control()/nav_spacer()
         if self.content is None:
             return self.nav, None
@@ -199,14 +201,14 @@ def nav_spacer() -> Nav:
 
 
 class NavMenu:
-    nav_controls: List[NavSetArg]
+    nav_controls: list[NavSetArg]
     title: TagChildArg
     value: str
     align: Literal["left", "right"]
 
     def __init__(
         self,
-        *args: Union[NavSetArg, str],
+        *args: NavSetArg | str,
         title: TagChildArg,
         value: str,
         align: Literal["left", "right"] = "left",
@@ -219,8 +221,8 @@ class NavMenu:
     def resolve(
         self,
         selected: Optional[str],
-        context: Dict[str, Any],
-    ) -> Tuple[TagChildArg, TagChildArg]:
+        context: dict[str, Any],
+    ) -> tuple[TagChildArg, TagChildArg]:
         nav, content = render_navset(
             *self.nav_controls,
             ul_class=f"dropdown-menu {'dropdown-menu-right' if self.align == 'right' else ''}",
@@ -264,7 +266,7 @@ class NavMenu:
         raise NotImplementedError("nav_menu() must appear within navset_*() container.")
 
 
-def menu_string_as_nav(x: Union[str, NavSetArg]) -> NavSetArg:
+def menu_string_as_nav(x: str | NavSetArg) -> NavSetArg:
     if not isinstance(x, str):
         return x
 
@@ -278,7 +280,7 @@ def menu_string_as_nav(x: Union[str, NavSetArg]) -> NavSetArg:
 
 def nav_menu(
     title: TagChildArg,
-    *args: Union[Nav, str],
+    *args: Nav | str,
     value: Optional[str] = None,
     icon: TagChildArg = None,
     align: Literal["left", "right"] = "left",
@@ -337,7 +339,7 @@ def nav_menu(
 
 
 class NavSet:
-    args: Tuple[NavSetArg]
+    args: tuple[NavSetArg]
     ul_class: str
     id: Optional[str]
     selected: Optional[str]
@@ -360,7 +362,7 @@ class NavSet:
         self.header = header
         self.footer = footer
 
-    def tagify(self) -> Union[TagList, Tag]:
+    def tagify(self) -> TagList | Tag:
         id = self.id
         ul_class = self.ul_class
         if id is not None:
@@ -371,7 +373,7 @@ class NavSet:
         )
         return self.layout(nav, content)
 
-    def layout(self, nav: TagChildArg, content: TagChildArg) -> Union[TagList, Tag]:
+    def layout(self, nav: TagChildArg, content: TagChildArg) -> TagList | Tag:
         return TagList(nav, self.header, content, self.footer)
 
 
@@ -674,7 +676,7 @@ def navset_pill_card(
 
 class NavSetPillList(NavSet):
     well: bool
-    widths: Tuple[int, int]
+    widths: tuple[int, int]
 
     def __init__(
         self,
@@ -685,7 +687,7 @@ class NavSetPillList(NavSet):
         header: TagChildArg = None,
         footer: TagChildArg = None,
         well: bool = True,
-        widths: Tuple[int, int] = (4, 8),
+        widths: tuple[int, int] = (4, 8),
     ) -> None:
         super().__init__(
             *args,
@@ -713,7 +715,7 @@ def navset_pill_list(
     header: TagChildArg = None,
     footer: TagChildArg = None,
     well: bool = True,
-    widths: Tuple[int, int] = (4, 8),
+    widths: tuple[int, int] = (4, 8),
 ) -> NavSet:
     """
     Render nav items as a vertical pillset.
@@ -950,8 +952,8 @@ def render_navset(
     ul_class: str,
     id: Optional[str],
     selected: Optional[str],
-    context: Dict[str, Any],
-) -> Tuple[Tag, Tag]:
+    context: dict[str, Any],
+) -> tuple[Tag, Tag]:
     tabsetid = private_random_int(1000, 10000)
 
     # If the user hasn't provided a selected value, use the first one

--- a/shiny/ui/_notification.py
+++ b/shiny/ui/_notification.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 __all__ = ("notification_show", "notification_remove")
 
 import sys
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -19,7 +21,7 @@ from ..session import Session, require_active_session
 def notification_show(
     ui: TagChildArg,
     action: Optional[TagList] = None,
-    duration: Optional[Union[int, float]] = 5,
+    duration: Optional[int | float] = 5,
     close_button: bool = True,
     id: Optional[str] = None,
     type: Literal["default", "message", "warning", "error"] = "default",
@@ -70,7 +72,7 @@ def notification_show(
 
     id = id if id else rand_hex(8)
 
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "html": ui_["html"],
         "action": action_["html"],
         "deps": ui_["deps"] + action_["deps"],

--- a/shiny/ui/_output.py
+++ b/shiny/ui/_output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = (
     "output_plot",
     "output_image",
@@ -7,7 +9,7 @@ __all__ = (
     "output_ui",
 )
 
-from typing import Dict, Optional, Union
+from typing import Optional
 
 from htmltools import Tag, TagAttrArg, TagFunction, css, div, tags
 
@@ -33,10 +35,10 @@ def output_plot(
     height: str = "400px",
     *,
     inline: bool = False,
-    click: Union[bool, ClickOpts] = False,
-    dblclick: Union[bool, DblClickOpts] = False,
-    hover: Union[bool, HoverOpts] = False,
-    brush: Union[bool, BrushOpts] = False,
+    click: bool | ClickOpts = False,
+    dblclick: bool | DblClickOpts = False,
+    hover: bool | HoverOpts = False,
+    brush: bool | BrushOpts = False,
 ) -> Tag:
     """
     Create a output container for a static plot.
@@ -113,10 +115,10 @@ def output_image(
     height: str = "400px",
     *,
     inline: bool = False,
-    click: Union[bool, ClickOpts] = False,
-    dblclick: Union[bool, DblClickOpts] = False,
-    hover: Union[bool, HoverOpts] = False,
-    brush: Union[bool, BrushOpts] = False,
+    click: bool | ClickOpts = False,
+    dblclick: bool | DblClickOpts = False,
+    hover: bool | HoverOpts = False,
+    brush: bool | BrushOpts = False,
 ) -> Tag:
     """
     Create a output container for a static image.
@@ -173,7 +175,7 @@ def output_image(
     func = tags.span if inline else div
     style = None if inline else css(width=width, height=height)
 
-    args: Dict[str, str] = dict()
+    args: dict[str, str] = dict()
 
     id_resolved = resolve_id(id)
 

--- a/shiny/ui/_page.py
+++ b/shiny/ui/_page.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = (
     "page_navbar",
     "page_fluid",
@@ -6,7 +8,7 @@ __all__ = (
 )
 
 import sys
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -28,7 +30,7 @@ from ._utils import get_window_title
 
 def page_navbar(
     *args: NavSetArg,
-    title: Optional[Union[str, Tag, TagList]] = None,
+    title: Optional[str | Tag | TagList] = None,
     id: Optional[str] = None,
     selected: Optional[str] = None,
     position: Literal["static-top", "fixed-top", "fixed-bottom"] = "static-top",
@@ -38,8 +40,8 @@ def page_navbar(
     inverse: bool = False,
     collapsible: bool = True,
     fluid: bool = True,
-    window_title: Union[str, MISSING_TYPE] = MISSING,
-    lang: Optional[str] = None
+    window_title: str | MISSING_TYPE = MISSING,
+    lang: Optional[str] = None,
 ) -> Tag:
     """
     Create a navbar with a navs bar and a title.
@@ -116,7 +118,7 @@ def page_navbar(
                 bg=bg,
                 inverse=inverse,
                 collapsible=collapsible,
-                fluid=fluid
+                fluid=fluid,
             )
         ),
         lang=lang,

--- a/shiny/ui/_plot_output_opts.py
+++ b/shiny/ui/_plot_output_opts.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import re
 import sys
-from typing import Dict, Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -51,10 +52,10 @@ class BrushOpts(TypedDict):
 # is a TypedDict, and that is _not_ a subclass of Dict because it doesn't support some
 # Dict operations, like removing items specified in the TypedDict.
 def format_opt_names(
-    opts: Union[ClickOpts, DblClickOpts, HoverOpts, BrushOpts],
+    opts: ClickOpts | DblClickOpts | HoverOpts | BrushOpts,
     prefix: str,
-) -> Dict[str, str]:
-    new_opts: Dict[str, str] = dict()
+) -> dict[str, str]:
+    new_opts: dict[str, str] = dict()
     for key, value in opts.items():
         new_key = f"data-{prefix}-" + re.sub("([A-Z])", "-\\1", key).lower()
         new_value = str(value)

--- a/shiny/ui/_progress.py
+++ b/shiny/ui/_progress.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 __all__ = ("Progress",)
 
 from types import TracebackType
-from typing import Optional, Type, Union
+from typing import Optional, Type
 from warnings import warn
 
 from .._docstring import add_example
@@ -31,7 +33,7 @@ class Progress:
 
     min: int
     max: int
-    value: Union[float, None]
+    value: float | None
 
     def __init__(
         self, min: int = 0, max: int = 1, session: Optional[Session] = None

--- a/shiny/ui/_utils.py
+++ b/shiny/ui/_utils.py
@@ -1,4 +1,6 @@
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import Optional
 
 from htmltools import (
     HTMLDependency,
@@ -19,8 +21,8 @@ def shiny_input_label(id: str, label: TagChildArg = None) -> Tag:
 
 
 def get_window_title(
-    title: Optional[Union[str, Tag, TagList]],
-    window_title: Union[str, MISSING_TYPE] = MISSING,
+    title: Optional[str | Tag | TagList],
+    window_title: str | MISSING_TYPE = MISSING,
 ) -> Optional[HTMLDependency]:
     if title is not None and isinstance(window_title, MISSING_TYPE):
         window_title = _find_child_strings(title)
@@ -31,7 +33,7 @@ def get_window_title(
         return head_content(tags.title(window_title))
 
 
-def _find_child_strings(x: Union[Tag, TagList, TagChild]) -> str:
+def _find_child_strings(x: Tag | TagList | TagChild) -> str:
     if isinstance(x, Tag) and x.name not in ("script", "style"):
         x = x.children
     if isinstance(x, TagList):


### PR DESCRIPTION
This PR switches away from using `Union`, `Dict`, and `List` whenever possible, by using `from __future__ import annotations`.