### PR TITLE
Use types from htmltools 0.1.4.9001

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -28,13 +28,9 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
-      - name: Check out and install htmltools
+      - name: Install dev version of htmltools
         run: |
-          cd ..
-          git clone https://github.com/rstudio/py-htmltools.git
-          cd py-htmltools
-          pip install wheel
-          make install
+          pip install wheel https://github.com/rstudio/py-htmltools/tarball/main
 
       # - name: Check out and install fontawesome
       #   run: |

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,9 @@ dist: clean ## builds source and wheel package
 	ls -l dist
 
 ## install the package to the active Python's site-packages
-# Note that py-htmltools/ must be a sibling directory of py-shiny/.
+# Note that instead of --force-reinstall, we uninstall and then install, because
+# --force-reinstall also reinstalls all deps. And if we also used --no-deps, then the
+# deps wouldn't be installed the first time.
 install: dist
-	python3 -m pip install --force-reinstall dist/shiny*.whl --find-links ../py-htmltools/dist/
+	pip uninstall -y shiny
+	python3 -m pip install dist/shiny*.whl

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     contextvars>=2.4
     websockets>=10.0
     python-multipart
-    htmltools>=0.1.0.9001
+    htmltools>=0.1.4.9001
     click>=8.0.3
     markdown-it-py>=1.1.0
     # This is needed for markdown-it-py. Without it, when loading shiny/ui/_markdown.py,

--- a/shiny/examples/Module/app.py
+++ b/shiny/examples/Module/app.py
@@ -5,7 +5,7 @@ from shiny import *
 # Counter module
 # ============================================================
 @module.ui
-def counter_ui(label: str = "Increment counter") -> ui.TagChildArg:
+def counter_ui(label: str = "Increment counter") -> ui.TagChild:
     return ui.div(
         {"style": "border: 1px solid #ccc; border-radius: 5px; margin: 5px 0;"},
         ui.h2("This is " + label),

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -42,12 +42,12 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Protocol, runtime_checkable
 
-# These aren't used directly in this file, but they seems necessary for Sphinx to work
+# These aren't used directly in this file, but they seem necessary for Sphinx to work
 # cleanly.
 from htmltools import Tag  # pyright: ignore[reportUnusedImport] # noqa: F401
-from htmltools import TagChildArg  # pyright: ignore[reportUnusedImport] # noqa: F401
 from htmltools import Tagifiable  # pyright: ignore[reportUnusedImport] # noqa: F401
 from htmltools import TagList  # pyright: ignore[reportUnusedImport] # noqa: F401
+from htmltools import TagChild
 
 if TYPE_CHECKING:
     from ..session import Session
@@ -670,11 +670,11 @@ def table(
 # ======================================================================================
 # RenderUI
 # ======================================================================================
-RenderUIFunc = Callable[[], TagChildArg]
-RenderUIFuncAsync = Callable[[], Awaitable[TagChildArg]]
+RenderUIFunc = Callable[[], TagChild]
+RenderUIFuncAsync = Callable[[], Awaitable[TagChild]]
 
 
-class RenderUI(RenderFunction[TagChildArg, "RenderedDeps | None"]):
+class RenderUI(RenderFunction[TagChild, "RenderedDeps | None"]):
     def __init__(self, fn: RenderUIFunc) -> None:
         super().__init__(fn)
         # The Render*Async subclass will pass in an async function, but it tells the
@@ -686,14 +686,14 @@ class RenderUI(RenderFunction[TagChildArg, "RenderedDeps | None"]):
         return _utils.run_coro_sync(self._run())
 
     async def _run(self) -> RenderedDeps | None:
-        ui: TagChildArg = await self._fn()
+        ui: TagChild = await self._fn()
         if ui is None:
             return None
 
         return self._session._process_ui(ui)
 
 
-class RenderUIAsync(RenderUI, RenderFunctionAsync[TagChildArg, "RenderedDeps| None"]):
+class RenderUIAsync(RenderUI, RenderFunctionAsync[TagChild, "RenderedDeps| None"]):
     def __init__(self, fn: RenderUIFuncAsync) -> None:
         if not _utils.is_async_callable(fn):
             raise TypeError(self.__class__.__name__ + " requires an async function")
@@ -723,7 +723,7 @@ def ui(
 
     Returns
     -------
-    A decorator for a function that returns an object of type `~shiny.ui.TagChildArg`.
+    A decorator for a function that returns an object of type `~shiny.ui.TagChild`.
 
     Tip
     ----
@@ -738,7 +738,7 @@ def ui(
     """
 
     def wrapper(
-        fn: Callable[[], TagChildArg] | Callable[[], Awaitable[TagChildArg]]
+        fn: Callable[[], TagChild] | Callable[[], Awaitable[TagChild]]
     ) -> RenderUI:
         if _utils.is_async_callable(fn):
             return RenderUIAsync(fn)

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -39,7 +39,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import TypedDict
 
-from htmltools import TagChildArg, TagList
+from htmltools import TagChild, TagList
 
 if TYPE_CHECKING:
     from .._app import App
@@ -802,7 +802,7 @@ class Session(object, metaclass=SessionMeta):
         nonce = _utils.rand_hex(8)
         return f"session/{urllib.parse.quote(self.id)}/dynamic_route/{urllib.parse.quote(name)}?nonce={urllib.parse.quote(nonce)}"
 
-    def _process_ui(self, ui: TagChildArg) -> RenderedDeps:
+    def _process_ui(self, ui: TagChild) -> RenderedDeps:
         res = TagList(ui).render()
         deps: list[dict[str, Any]] = []
         for dep in res["dependencies"]:

--- a/shiny/types.py
+++ b/shiny/types.py
@@ -28,7 +28,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal, Protocol
 
-from htmltools import TagChildArg
+from htmltools import TagChild
 
 from ._docstring import add_example
 
@@ -163,7 +163,7 @@ class NavSetArg(Protocol):
 
     def resolve(
         self, selected: Optional[str], context: dict[str, Any]
-    ) -> tuple[TagChildArg, TagChildArg]:
+    ) -> tuple[TagChild, TagChild]:
         """
         Resolve information provided by the navigation container.
 

--- a/shiny/ui/__init__.py
+++ b/shiny/ui/__init__.py
@@ -80,8 +80,9 @@ from ._progress import Progress
 from htmltools import (
     TagList,
     Tag,
-    TagChildArg,
-    TagAttrArg,
+    TagChild,
+    TagAttrs,
+    TagAttrValue,
     tags,
     HTML,
     head_content,
@@ -191,8 +192,9 @@ __all__ = (
     # Items below are from htmltools
     "TagList",
     "Tag",
-    "TagChildArg",
-    "TagAttrArg",
+    "TagChild",
+    "TagAttrs",
+    "TagAttrValue",
     "tags",
     "HTML",
     "head_content",

--- a/shiny/ui/_bootstrap.py
+++ b/shiny/ui/_bootstrap.py
@@ -24,7 +24,18 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-from htmltools import Tag, TagAttrArg, TagChildArg, TagList, css, div, h2, span, tags
+from htmltools import (
+    Tag,
+    TagAttrs,
+    TagAttrValue,
+    TagChild,
+    TagList,
+    css,
+    div,
+    h2,
+    span,
+    tags,
+)
 
 from .._docstring import add_example
 from ..module import current_namespace
@@ -34,7 +45,7 @@ from ._utils import get_window_title
 
 # TODO: make a python version of the layout guide?
 @add_example()
-def row(*args: TagChildArg, **kwargs: TagAttrArg) -> Tag:
+def row(*args: TagChild | TagAttrs, **kwargs: TagAttrValue) -> Tag:
     """
     Responsive row-column based layout
 
@@ -48,13 +59,13 @@ def row(*args: TagChildArg, **kwargs: TagAttrArg) -> Tag:
     Parameters
     ----------
     args
-        Any number of child elements
+        Any number of child elements.
     kwargs
-        Attributes to place on the row tag
+        Attributes to place on the row tag.
 
     Returns
     -------
-    A UI element
+    A UI element.
 
     See Also
     -------
@@ -64,7 +75,7 @@ def row(*args: TagChildArg, **kwargs: TagAttrArg) -> Tag:
 
 
 def column(
-    width: int, *args: TagChildArg, offset: int = 0, **kwargs: TagAttrArg
+    width: int, *args: TagChild | TagAttrs, offset: int = 0, **kwargs: TagAttrValue
 ) -> Tag:
     """
     Responsive row-column based layout
@@ -74,17 +85,17 @@ def column(
     Parameters
     ----------
     width
-        The width of the column (an integer between 1 and 12)
+        The width of the column (an integer between 1 and 12).
     args
-        UI elements to place within the column
+        UI elements to place within the column.
     offset
         The number of columns to offset this column from the end of the previous column.
     kwargs
-        Attributes to place on the column tag
+        Attributes to place on the column tag.
 
     Returns
     -------
-    A UI element
+    A UI element.
 
     See Also
     -------
@@ -106,8 +117,8 @@ def column(
 @add_example()
 def layout_sidebar(
     # TODO: also accept a generic list (and wrap in panel in that case)?
-    sidebar: TagChildArg,
-    main: TagChildArg,
+    sidebar: TagChild,
+    main: TagChild,
     position: Literal["left", "right"] = "left",
 ) -> Tag:
     """
@@ -141,7 +152,7 @@ def layout_sidebar(
     return row(sidebar, main) if position == "left" else row(main, sidebar)
 
 
-def panel_well(*args: TagChildArg, **kwargs: TagAttrArg) -> Tag:
+def panel_well(*args: TagChild | TagAttrs, **kwargs: TagAttrValue) -> Tag:
     """
     Create a well panel
 
@@ -157,7 +168,7 @@ def panel_well(*args: TagChildArg, **kwargs: TagAttrArg) -> Tag:
 
     Returns
     -------
-    A UI element
+    A UI element.
 
     See Also
     -------
@@ -167,7 +178,9 @@ def panel_well(*args: TagChildArg, **kwargs: TagAttrArg) -> Tag:
     return div({"class": "well"}, *args, **kwargs)
 
 
-def panel_sidebar(*args: TagChildArg, width: int = 4, **kwargs: TagAttrArg) -> Tag:
+def panel_sidebar(
+    *args: TagChild | TagAttrs, width: int = 4, **kwargs: TagAttrValue
+) -> Tag:
     """
     Create a sidebar panel
 
@@ -185,7 +198,7 @@ def panel_sidebar(*args: TagChildArg, width: int = 4, **kwargs: TagAttrArg) -> T
 
     Returns
     -------
-    A UI element
+    A UI element.
 
     See Also
     -------
@@ -199,7 +212,9 @@ def panel_sidebar(*args: TagChildArg, width: int = 4, **kwargs: TagAttrArg) -> T
     )
 
 
-def panel_main(*args: TagChildArg, width: int = 8, **kwargs: TagAttrArg) -> Tag:
+def panel_main(
+    *args: TagChild | TagAttrs, width: int = 8, **kwargs: TagAttrValue
+) -> Tag:
     """
     Create an main area panel
 
@@ -210,13 +225,13 @@ def panel_main(*args: TagChildArg, width: int = 8, **kwargs: TagAttrArg) -> Tag:
     args
         UI elements to include inside the main area.
     width
-        The width of the main area (an integer between 1 and 12)
+        The width of the main area (an integer between 1 and 12).
     kwargs
         Attributes to place on the main area tag.
 
     Returns
     -------
-    A UI element
+    A UI element.
 
     See Also
     -------
@@ -240,8 +255,8 @@ def panel_main(*args: TagChildArg, width: int = 8, **kwargs: TagAttrArg) -> Tag:
 @add_example()
 def panel_conditional(
     condition: str,
-    *args: TagChildArg,
-    **kwargs: TagAttrArg,
+    *args: TagChild | TagAttrs,
+    **kwargs: TagAttrValue,
 ) -> Tag:
     """
     Create a conditional panel
@@ -260,7 +275,7 @@ def panel_conditional(
 
     Returns
     -------
-    A UI element
+    A UI element.
 
     Note
     ----
@@ -309,7 +324,7 @@ def panel_title(
 
     Returns
     -------
-    A UI element
+    A UI element.
 
     Note
     ----
@@ -325,7 +340,7 @@ def panel_title(
     return TagList(get_window_title(title, window_title), title)
 
 
-def panel_fixed(*args: TagChildArg, **kwargs: TagAttrArg) -> TagList:
+def panel_fixed(*args: TagChild | TagAttrs, **kwargs: TagAttrValue) -> TagList:
     """
     Create a panel of absolutely positioned content.
 
@@ -342,7 +357,7 @@ def panel_fixed(*args: TagChildArg, **kwargs: TagAttrArg) -> TagList:
 
     Returns
     -------
-    A UI element
+    A UI element.
 
     See Also
     -------
@@ -353,7 +368,7 @@ def panel_fixed(*args: TagChildArg, **kwargs: TagAttrArg) -> TagList:
 
 @add_example()
 def panel_absolute(
-    *args: TagChildArg,
+    *args: TagChild | TagAttrs,
     top: Optional[str] = None,
     left: Optional[str] = None,
     right: Optional[str] = None,
@@ -363,7 +378,7 @@ def panel_absolute(
     draggable: bool = False,
     fixed: bool = False,
     cursor: Literal["auto", "move", "default", "inherit"] = "auto",
-    **kwargs: TagAttrArg,
+    **kwargs: TagAttrValue,
 ) -> TagList:
     """
     Create a panel of absolutely positioned content.
@@ -448,7 +463,7 @@ def panel_absolute(
     return TagList(deps, divTag, tags.script('$(".draggable").draggable();'))
 
 
-def help_text(*args: TagChildArg, **kwargs: TagAttrArg) -> Tag:
+def help_text(*args: TagChild | TagAttrs, **kwargs: TagAttrValue) -> Tag:
     """
     Create a help text element
 

--- a/shiny/ui/_download_button.py
+++ b/shiny/ui/_download_button.py
@@ -2,7 +2,7 @@ __all__ = ("download_button", "download_link")
 
 from typing import Optional
 
-from htmltools import Tag, TagAttrArg, TagChildArg, css, tags
+from htmltools import Tag, TagAttrValue, TagChild, css, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -12,10 +12,11 @@ from .._shinyenv import is_pyodide
 @add_example()
 def download_button(
     id: str,
-    label: TagChildArg,
-    icon: TagChildArg = None,
+    label: TagChild,
+    *,
+    icon: TagChild = None,
     width: Optional[str] = None,
-    **kwargs: TagAttrArg,
+    **kwargs: TagAttrValue,
 ) -> Tag:
     """
     Create a download button
@@ -65,10 +66,11 @@ def download_button(
 @add_example()
 def download_link(
     id: str,
-    label: TagChildArg,
-    icon: TagChildArg = None,
+    label: TagChild,
+    *,
+    icon: TagChild = None,
     width: Optional[str] = None,
-    **kwargs: TagAttrArg,
+    **kwargs: TagAttrValue,
 ) -> Tag:
     """
     Create a download button

--- a/shiny/ui/_input_action_button.py
+++ b/shiny/ui/_input_action_button.py
@@ -2,7 +2,7 @@ __all__ = ("input_action_button", "input_action_link")
 
 from typing import Optional
 
-from htmltools import Tag, TagAttrArg, TagChildArg, css, tags
+from htmltools import Tag, TagAttrValue, TagChild, css, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -11,11 +11,11 @@ from .._namespaces import resolve_id
 @add_example()
 def input_action_button(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     *,
-    icon: TagChildArg = None,
+    icon: TagChild = None,
     width: Optional[str] = None,
-    **kwargs: TagAttrArg,
+    **kwargs: TagAttrValue,
 ) -> Tag:
     """
     Creates an action button whose value is initially zero, and increments by one each
@@ -63,10 +63,10 @@ def input_action_button(
 @add_example()
 def input_action_link(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     *,
-    icon: TagChildArg = None,
-    **kwargs: TagAttrArg,
+    icon: TagChild = None,
+    **kwargs: TagAttrValue,
 ) -> Tag:
     """
     Creates a link whose value is initially zero, and increments by one each time it is

--- a/shiny/ui/_input_check_radio.py
+++ b/shiny/ui/_input_check_radio.py
@@ -8,14 +8,14 @@ __all__ = (
 
 from typing import Mapping, Optional, Union
 
-from htmltools import Tag, TagChildArg, css, div, span, tags
+from htmltools import Tag, TagChild, css, div, span, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
 from ._utils import shiny_input_label
 
 # Canonical format for representing select options.
-_Choices = Mapping[str, TagChildArg]
+_Choices = Mapping[str, TagChild]
 
 # Formats available to the user
 ChoicesArg = Union["list[str]", _Choices]
@@ -23,7 +23,7 @@ ChoicesArg = Union["list[str]", _Choices]
 
 @add_example()
 def input_checkbox(
-    id: str, label: TagChildArg, value: bool = False, *, width: Optional[str] = None
+    id: str, label: TagChild, value: bool = False, *, width: Optional[str] = None
 ) -> Tag:
     """
     Create a checkbox that can be used to specify logical values.
@@ -76,7 +76,7 @@ def input_checkbox(
 
 @add_example()
 def input_switch(
-    id: str, label: TagChildArg, value: bool = False, *, width: Optional[str] = None
+    id: str, label: TagChild, value: bool = False, *, width: Optional[str] = None
 ) -> Tag:
     """
     Create a switch that can be used to specify logical values. Similar to
@@ -117,7 +117,7 @@ def input_switch(
 
 def _input_checkbox(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     class_: str = "form-check",
     value: bool = False,
     *,
@@ -142,7 +142,7 @@ def _input_checkbox(
 @add_example()
 def input_checkbox_group(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     choices: ChoicesArg,
     *,
     selected: Optional[str | list[str]] = None,
@@ -211,7 +211,7 @@ def input_checkbox_group(
 @add_example()
 def input_radio_buttons(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     choices: ChoicesArg,
     *,
     selected: Optional[str] = None,
@@ -313,7 +313,7 @@ def _generate_option(
     id: str,
     type: str,
     value: str,
-    label: TagChildArg,
+    label: TagChild,
     checked: bool,
     inline: bool,
 ) -> Tag:

--- a/shiny/ui/_input_date.py
+++ b/shiny/ui/_input_date.py
@@ -6,7 +6,7 @@ import json
 from datetime import date
 from typing import Optional
 
-from htmltools import Tag, TagAttrArg, TagChildArg, css, div, span, tags
+from htmltools import Tag, TagAttrValue, TagChild, css, div, span, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -17,7 +17,7 @@ from ._utils import shiny_input_label
 @add_example()
 def input_date(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     *,
     value: Optional[date | str] = None,
     min: Optional[date | str] = None,
@@ -133,7 +133,7 @@ def input_date(
 @add_example()
 def input_date_range(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     *,
     start: Optional[date | str] = None,
     end: Optional[date | str] = None,
@@ -275,7 +275,7 @@ def _date_input_tag(
     weekstart: int,
     language: str,
     autoclose: bool,
-    **kwargs: TagAttrArg,
+    **kwargs: TagAttrValue,
 ):
     return tags.input(
         datepicker_deps(),

--- a/shiny/ui/_input_file.py
+++ b/shiny/ui/_input_file.py
@@ -10,7 +10,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-from htmltools import Tag, TagChildArg, css, div, span, tags
+from htmltools import Tag, TagChild, css, div, span, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -20,7 +20,7 @@ from ._utils import shiny_input_label
 @add_example()
 def input_file(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     *,
     multiple: bool = False,
     accept: Optional[str | list[str]] = None,

--- a/shiny/ui/_input_numeric.py
+++ b/shiny/ui/_input_numeric.py
@@ -2,7 +2,7 @@ __all__ = ("input_numeric",)
 
 from typing import Optional
 
-from htmltools import Tag, TagChildArg, css, div, tags
+from htmltools import Tag, TagChild, css, div, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -12,7 +12,7 @@ from ._utils import shiny_input_label
 @add_example()
 def input_numeric(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     value: float,
     *,
     min: Optional[float] = None,

--- a/shiny/ui/_input_password.py
+++ b/shiny/ui/_input_password.py
@@ -2,7 +2,7 @@ __all__ = ("input_password",)
 
 from typing import Optional
 
-from htmltools import Tag, TagChildArg, css, div, tags
+from htmltools import Tag, TagChild, css, div, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -12,7 +12,7 @@ from ._utils import shiny_input_label
 @add_example()
 def input_password(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     value: str = "",
     *,
     width: Optional[str] = None,

--- a/shiny/ui/_input_select.py
+++ b/shiny/ui/_input_select.py
@@ -9,14 +9,14 @@ __all__ = (
 
 from typing import Mapping, Optional, Union, cast
 
-from htmltools import Tag, TagChildArg, TagList, css, div, tags
+from htmltools import Tag, TagChild, TagList, css, div, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
 from ._html_dependencies import selectize_deps
 from ._utils import shiny_input_label
 
-_Choices = Mapping[str, TagChildArg]
+_Choices = Mapping[str, TagChild]
 _OptGrpChoices = Mapping[str, _Choices]
 
 # Canonical format for representing select options.
@@ -46,7 +46,7 @@ A list of strings, usually of length 1, with the value of the selected items. Wh
 @add_example()
 def input_selectize(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     choices: SelectChoicesArg,
     *,
     selected: Optional[str | list[str]] = None,
@@ -106,7 +106,7 @@ def input_selectize(
 @add_example()
 def input_select(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     choices: SelectChoicesArg,
     *,
     selected: Optional[str | list[str]] = None,

--- a/shiny/ui/_input_slider.py
+++ b/shiny/ui/_input_slider.py
@@ -12,7 +12,7 @@ import sys
 from datetime import date, datetime, timedelta
 from typing import Iterable, Optional, TypeVar, Union, cast
 
-from htmltools import HTML, Tag, TagAttrArg, TagChildArg, css, div, tags
+from htmltools import HTML, Tag, TagAttrValue, TagChild, css, div, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -59,14 +59,14 @@ class AnimationOptions(TypedDict):
 
     interval: NotRequired[int]
     loop: NotRequired[bool]
-    play_button: NotRequired[TagChildArg]
-    pause_button: NotRequired[TagChildArg]
+    play_button: NotRequired[TagChild]
+    pause_button: NotRequired[TagChild]
 
 
 @add_example()
 def input_slider(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     min: SliderValueArg,
     max: SliderValueArg,
     value: SliderValueArg | Iterable[SliderValueArg],
@@ -174,7 +174,7 @@ def input_slider(
 
     id = resolve_id(id)
 
-    props: dict[str, TagAttrArg] = {
+    props: dict[str, TagAttrValue] = {
         "class_": "js-range-slider",
         "id": id,
         "data_skin": "shiny",

--- a/shiny/ui/_input_text.py
+++ b/shiny/ui/_input_text.py
@@ -8,7 +8,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-from htmltools import Tag, TagChildArg, css, div, tags
+from htmltools import Tag, TagChild, css, div, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -18,7 +18,7 @@ from ._utils import shiny_input_label
 @add_example()
 def input_text(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     value: str = "",
     *,
     width: Optional[str] = None,
@@ -86,7 +86,7 @@ def input_text(
 @add_example()
 def input_text_area(
     id: str,
-    label: TagChildArg,
+    label: TagChild,
     value: str = "",
     *,
     width: Optional[str] = None,

--- a/shiny/ui/_input_update.py
+++ b/shiny/ui/_input_update.py
@@ -37,7 +37,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal, TypedDict
 
-from htmltools import TagChildArg
+from htmltools import TagChild
 
 from .._docstring import add_example, doc_format
 from .._namespaces import resolve_id
@@ -76,7 +76,7 @@ def update_action_button(
     id: str,
     *,
     label: Optional[str] = None,
-    icon: TagChildArg = None,
+    icon: TagChild = None,
     session: Optional[Session] = None,
 ) -> None:
     """
@@ -104,7 +104,7 @@ def update_action_button(
     """
 
     session = require_active_session(session)
-    # TODO: supporting a TagChildArg for label would require changes to shiny.js
+    # TODO: supporting a TagChild for label would require changes to shiny.js
     # https://github.com/rstudio/shiny/issues/1140
     msg = {"label": label, "icon": session._process_ui(icon)["html"] if icon else None}
     session.send_input_message(id, drop_none(msg))

--- a/shiny/ui/_insert.py
+++ b/shiny/ui/_insert.py
@@ -8,7 +8,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-from htmltools import TagChildArg
+from htmltools import TagChild
 
 from .._docstring import add_example
 from ..session import Session, require_active_session
@@ -16,7 +16,7 @@ from ..session import Session, require_active_session
 
 @add_example()
 def insert_ui(
-    ui: TagChildArg,
+    ui: TagChild,
     selector: str,
     where: Literal["beforeBegin", "afterBegin", "beforeEnd", "afterEnd"] = "beforeEnd",
     multiple: bool = False,

--- a/shiny/ui/_modal.py
+++ b/shiny/ui/_modal.py
@@ -17,15 +17,13 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-from htmltools import HTML, Tag, TagAttrArg, TagChildArg, div, tags
+from htmltools import HTML, Tag, TagAttrs, TagAttrValue, TagChild, div, tags
 
 from .._docstring import add_example
 from ..session import Session, require_active_session
 
 
-def modal_button(
-    label: TagChildArg, icon: TagChildArg = None, **kwargs: TagChildArg
-) -> Tag:
+def modal_button(label: TagChild, icon: TagChild = None, **kwargs: TagAttrValue) -> Tag:
     """
     Creates a button that will dismiss a :func:`modal` (useful when customising the
     ``footer`` of :func:`modal`).
@@ -66,13 +64,13 @@ def modal_button(
 
 @add_example()
 def modal(
-    *args: TagChildArg,
+    *args: TagChild | TagAttrs,
     title: Optional[str] = None,
-    footer: TagChildArg | MISSING_TYPE = MISSING,
+    footer: TagChild | MISSING_TYPE = MISSING,
     size: Literal["m", "s", "l", "xl"] = "m",
     easy_close: bool = False,
     fade: bool = True,
-    **kwargs: TagAttrArg,
+    **kwargs: TagAttrValue,
 ) -> Tag:
     """
     Creates the UI for a modal dialog, using Bootstrap's modal class. Modals are

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -24,7 +24,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-from htmltools import Tag, TagChildArg, TagList, div, tags
+from htmltools import Tag, TagChild, TagList, div, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -48,7 +48,7 @@ class Nav:
 
     def resolve(
         self, selected: Optional[str], context: dict[str, Any]
-    ) -> tuple[TagChildArg, TagChildArg]:
+    ) -> tuple[TagChild, TagChild]:
         # Nothing to do for nav_control()/nav_spacer()
         if self.content is None:
             return self.nav, None
@@ -94,10 +94,10 @@ class Nav:
 
 @add_example()
 def nav(
-    title: TagChildArg,
-    *args: TagChildArg,
+    title: TagChild,
+    *args: TagChild,
     value: Optional[str] = None,
-    icon: TagChildArg = None,
+    icon: TagChild = None,
 ) -> Nav:
     """
     Create a nav item pointing to some internal content.
@@ -149,7 +149,7 @@ def nav(
     )
 
 
-def nav_control(*args: TagChildArg) -> Nav:
+def nav_control(*args: TagChild) -> Nav:
     """
     Place a control in the navigation container.
 
@@ -202,14 +202,14 @@ def nav_spacer() -> Nav:
 
 class NavMenu:
     nav_controls: list[NavSetArg]
-    title: TagChildArg
+    title: TagChild
     value: str
     align: Literal["left", "right"]
 
     def __init__(
         self,
         *args: NavSetArg | str,
-        title: TagChildArg,
+        title: TagChild,
         value: str,
         align: Literal["left", "right"] = "left",
     ) -> None:
@@ -222,7 +222,7 @@ class NavMenu:
         self,
         selected: Optional[str],
         context: dict[str, Any],
-    ) -> tuple[TagChildArg, TagChildArg]:
+    ) -> tuple[TagChild, TagChild]:
         nav, content = render_navset(
             *self.nav_controls,
             ul_class=f"dropdown-menu {'dropdown-menu-right' if self.align == 'right' else ''}",
@@ -279,10 +279,10 @@ def menu_string_as_nav(x: str | NavSetArg) -> NavSetArg:
 
 
 def nav_menu(
-    title: TagChildArg,
+    title: TagChild,
     *args: Nav | str,
     value: Optional[str] = None,
-    icon: TagChildArg = None,
+    icon: TagChild = None,
     align: Literal["left", "right"] = "left",
 ) -> NavMenu:
     """
@@ -343,8 +343,8 @@ class NavSet:
     ul_class: str
     id: Optional[str]
     selected: Optional[str]
-    header: TagChildArg
-    footer: TagChildArg
+    header: TagChild
+    footer: TagChild
 
     def __init__(
         self,
@@ -352,8 +352,8 @@ class NavSet:
         ul_class: str,
         id: Optional[str],
         selected: Optional[str],
-        header: TagChildArg = None,
-        footer: TagChildArg = None,
+        header: TagChild = None,
+        footer: TagChild = None,
     ) -> None:
         self.args = args
         self.ul_class = ul_class
@@ -373,7 +373,7 @@ class NavSet:
         )
         return self.layout(nav, content)
 
-    def layout(self, nav: TagChildArg, content: TagChildArg) -> TagList | Tag:
+    def layout(self, nav: TagChild, content: TagChild) -> TagList | Tag:
         return TagList(nav, self.header, content, self.footer)
 
 
@@ -384,8 +384,8 @@ def navset_tab(
     *args: NavSetArg,
     id: Optional[str] = None,
     selected: Optional[str] = None,
-    header: TagChildArg = None,
-    footer: TagChildArg = None,
+    header: TagChild = None,
+    footer: TagChild = None,
 ) -> NavSet:
     """
     Render nav items as a tabset.
@@ -437,8 +437,8 @@ def navset_pill(
     *args: NavSetArg,
     id: Optional[str] = None,
     selected: Optional[str] = None,
-    header: TagChildArg = None,
-    footer: TagChildArg = None,
+    header: TagChild = None,
+    footer: TagChild = None,
 ) -> NavSet:
     """
     Render nav items as a pillset.
@@ -490,8 +490,8 @@ def navset_hidden(
     *args: NavSetArg,
     id: Optional[str] = None,
     selected: Optional[str] = None,
-    header: TagChildArg = None,
-    footer: TagChildArg = None,
+    header: TagChild = None,
+    footer: TagChild = None,
 ) -> NavSet:
     """
     Render nav contents without the nav items.
@@ -544,8 +544,8 @@ class NavSetCard(NavSet):
         ul_class: str,
         id: Optional[str],
         selected: Optional[str],
-        header: TagChildArg = None,
-        footer: TagChildArg = None,
+        header: TagChild = None,
+        footer: TagChild = None,
         placement: Literal["above", "below"] = "above",
     ) -> None:
         super().__init__(
@@ -558,7 +558,7 @@ class NavSetCard(NavSet):
         )
         self.placement = placement
 
-    def layout(self, nav: TagChildArg, content: TagChildArg) -> Tag:
+    def layout(self, nav: TagChild, content: TagChild) -> Tag:
         if self.placement == "below":
             return card(self.header, content, self.footer, footer=nav)
         else:
@@ -569,8 +569,8 @@ def navset_tab_card(
     *args: NavSetArg,
     id: Optional[str] = None,
     selected: Optional[str] = None,
-    header: TagChildArg = None,
-    footer: TagChildArg = None,
+    header: TagChild = None,
+    footer: TagChild = None,
 ) -> NavSetCard:
     """
     Render nav items as a tabset inside a card container.
@@ -622,8 +622,8 @@ def navset_pill_card(
     *args: NavSetArg,
     id: Optional[str] = None,
     selected: Optional[str] = None,
-    header: TagChildArg = None,
-    footer: TagChildArg = None,
+    header: TagChild = None,
+    footer: TagChild = None,
     placement: Literal["above", "below"] = "above",
 ) -> NavSetCard:
     """
@@ -684,8 +684,8 @@ class NavSetPillList(NavSet):
         ul_class: str,
         id: Optional[str],
         selected: Optional[str],
-        header: TagChildArg = None,
-        footer: TagChildArg = None,
+        header: TagChild = None,
+        footer: TagChild = None,
         well: bool = True,
         widths: tuple[int, int] = (4, 8),
     ) -> None:
@@ -700,7 +700,7 @@ class NavSetPillList(NavSet):
         self.well = well
         self.widths = widths
 
-    def layout(self, nav: TagChildArg, content: TagChildArg) -> Tag:
+    def layout(self, nav: TagChild, content: TagChild) -> Tag:
         widths = self.widths
         return row(
             column(widths[0], nav, class_="well" if self.well else None),
@@ -712,8 +712,8 @@ def navset_pill_list(
     *args: NavSetArg,
     id: Optional[str] = None,
     selected: Optional[str] = None,
-    header: TagChildArg = None,
-    footer: TagChildArg = None,
+    header: TagChild = None,
+    footer: TagChild = None,
     well: bool = True,
     widths: tuple[int, int] = (4, 8),
 ) -> NavSet:
@@ -773,7 +773,7 @@ def navset_pill_list(
 
 
 class NavSetBar(NavSet):
-    title: TagChildArg
+    title: TagChild
     position: Literal["static-top", "fixed-top", "fixed-bottom", "sticky-top"]
     bg: Optional[str]
     inverse: bool
@@ -784,14 +784,14 @@ class NavSetBar(NavSet):
         self,
         *args: NavSetArg,
         ul_class: str,
-        title: TagChildArg,
+        title: TagChild,
         id: Optional[str],
         selected: Optional[str],
         position: Literal[
             "static-top", "fixed-top", "fixed-bottom", "sticky-top"
         ] = "static-top",
-        header: TagChildArg = None,
-        footer: TagChildArg = None,
+        header: TagChild = None,
+        footer: TagChild = None,
         bg: Optional[str] = None,
         # TODO: default to 'auto', like we have in R (parse color via webcolors?)
         inverse: bool = False,
@@ -813,7 +813,7 @@ class NavSetBar(NavSet):
         self.collapsible = collapsible
         self.fluid = fluid
 
-    def layout(self, nav: TagChildArg, content: TagChildArg) -> TagList:
+    def layout(self, nav: TagChild, content: TagChild) -> TagList:
         nav_container = div(
             {"class": "container-fluid" if self.fluid else "container"},
             tags.a({"class": "navbar-brand", "href": "#"}, self.title),
@@ -860,14 +860,14 @@ class NavSetBar(NavSet):
 
 def navset_bar(
     *args: NavSetArg,
-    title: TagChildArg,
+    title: TagChild,
     id: Optional[str] = None,
     selected: Optional[str] = None,
     position: Literal[
         "static-top", "fixed-top", "fixed-bottom", "sticky-top"
     ] = "static-top",
-    header: TagChildArg = None,
-    footer: TagChildArg = None,
+    header: TagChild = None,
+    footer: TagChild = None,
     bg: Optional[str] = None,
     # TODO: default to 'auto', like we have in R (parse color via webcolors?)
     inverse: bool = False,
@@ -975,9 +975,7 @@ def render_navset(
     return ul_tag, div_tag
 
 
-def card(
-    *args: TagChildArg, header: TagChildArg = None, footer: TagChildArg = None
-) -> Tag:
+def card(*args: TagChild, header: TagChild = None, footer: TagChild = None) -> Tag:
     if header:
         header = div(header, class_="card-header")
     if footer:

--- a/shiny/ui/_notification.py
+++ b/shiny/ui/_notification.py
@@ -10,7 +10,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-from htmltools import TagChildArg, TagList
+from htmltools import TagChild
 
 from .._docstring import add_example
 from .._utils import rand_hex
@@ -19,8 +19,9 @@ from ..session import Session, require_active_session
 
 @add_example()
 def notification_show(
-    ui: TagChildArg,
-    action: Optional[TagList] = None,
+    ui: TagChild,
+    *,
+    action: Optional[TagChild] = None,
     duration: Optional[int | float] = 5,
     close_button: bool = True,
     id: Optional[str] = None,
@@ -89,7 +90,7 @@ def notification_show(
     return id
 
 
-def notification_remove(id: str, session: Optional[Session] = None) -> str:
+def notification_remove(id: str, *, session: Optional[Session] = None) -> str:
     """
     Remove a notification.
 

--- a/shiny/ui/_output.py
+++ b/shiny/ui/_output.py
@@ -11,7 +11,7 @@ __all__ = (
 
 from typing import Optional
 
-from htmltools import Tag, TagAttrArg, TagFunction, css, div, tags
+from htmltools import Tag, TagAttrValue, TagFunction, css, div, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -281,7 +281,7 @@ def output_text_verbatim(id: str, placeholder: bool = False) -> Tag:
 
 
 @add_example()
-def output_table(id: str, **kwargs: TagAttrArg) -> Tag:
+def output_table(id: str, **kwargs: TagAttrValue) -> Tag:
     """
     Create a output container for a table.
 
@@ -307,7 +307,7 @@ def output_ui(
     id: str,
     inline: bool = False,
     container: Optional[TagFunction] = None,
-    **kwargs: TagAttrArg,
+    **kwargs: TagAttrValue,
 ) -> Tag:
     """
     Create a output container for a UI (i.e., HTML) element.

--- a/shiny/ui/_page.py
+++ b/shiny/ui/_page.py
@@ -18,7 +18,7 @@ else:
 # Tagifiable isn't used directly in this file, but it seems to necessary to import
 # it somewhere for Sphinx to work cleanly.
 from htmltools import Tagifiable  # pyright: ignore[reportUnusedImport] # noqa: F401
-from htmltools import Tag, TagChildArg, TagList, div, tags
+from htmltools import Tag, TagChild, TagList, div, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
@@ -34,8 +34,8 @@ def page_navbar(
     id: Optional[str] = None,
     selected: Optional[str] = None,
     position: Literal["static-top", "fixed-top", "fixed-bottom"] = "static-top",
-    header: Optional[TagChildArg] = None,
-    footer: Optional[TagChildArg] = None,
+    header: Optional[TagChild] = None,
+    footer: Optional[TagChild] = None,
     bg: Optional[str] = None,
     inverse: bool = False,
     collapsible: bool = True,

--- a/shiny/ui/_utils.py
+++ b/shiny/ui/_utils.py
@@ -6,8 +6,8 @@ from htmltools import (
     HTMLDependency,
     Tag,
     TagChild,
-    TagChildArg,
     TagList,
+    TagNode,
     head_content,
     tags,
 )
@@ -15,7 +15,7 @@ from htmltools import (
 from ..types import MISSING, MISSING_TYPE
 
 
-def shiny_input_label(id: str, label: TagChildArg = None) -> Tag:
+def shiny_input_label(id: str, label: TagChild = None) -> Tag:
     cls = "control-label" + ("" if label else " shiny-label-null")
     return tags.label(label, class_=cls, id=id + "-label", for_=id)
 
@@ -33,7 +33,7 @@ def get_window_title(
         return head_content(tags.title(window_title))
 
 
-def _find_child_strings(x: Tag | TagList | TagChild) -> str:
+def _find_child_strings(x: TagList | TagNode) -> str:
     if isinstance(x, Tag) and x.name not in ("script", "style"):
         x = x.children
     if isinstance(x, TagList):


### PR DESCRIPTION
This PR updates Shiny to use types from htmltools 0.1.4.9001.