### PR TITLE
Update shinylive editor CSS class

### DIFF
--- a/docs/source/_static/js/disable-keypress.js
+++ b/docs/source/_static/js/disable-keypress.js
@@ -1,6 +1,6 @@
 // Don't allow keypresses that happen in the pyshiny editor
 // bubble up to the parent since Sphinx will, in that case, want
 // to navigate to another page on <- or ->.
-$(document).on("keydown", ".shinylive-container", function (e) {
+$(document).on("keydown", ".shinylive-wrapper", function (e) {
   e.stopPropagation();
 });


### PR DESCRIPTION
Closes #419 (I haven't actually confirmed this fixes the issue, but it should)