### PR TITLE
Remove `tox` from e2e testing

### DIFF
--- a/.github/requirements-tox.txt
+++ b/.github/requirements-tox.txt
@@ -1,2 +1,0 @@
-https://github.com/rstudio/py-htmltools/tarball/main
-https://github.com/rstudio/py-faicons/tarball/main

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Run e2e tests
         if: github.event_name != 'release' && steps.install.outcome == 'success' && (success() || failure())
         run: |
-          make test-e2e
+          make e2e
 
   deploy:
     name: "Deploy to PyPI"

--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,11 @@ test: ## run tests quickly with the default Python
 	python3 tests/asyncio_prevent.py
 	pytest
 
+# Default `FILE` to `e2e` if not specified
+FILE:=e2e
 e2e: ## run tests quickly with the default Python
 	playwright install --with-deps
-	pytest e2e --browser webkit --browser firefox --browser chromium  --numprocesses auto
+	pytest $(FILE) --browser webkit --browser firefox --browser chromium  --numprocesses auto
 
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source shiny -m pytest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help clean clean-test clean-pyc clean-build docs help lint test e2e test-all
+.PHONY: help clean clean-test clean-pyc clean-build docs help lint test e2e
 .DEFAULT_GOAL := help
 
 define BROWSER_PYSCRIPT
@@ -77,15 +77,9 @@ test: ## run tests quickly with the default Python
 	python3 tests/asyncio_prevent.py
 	pytest
 
-test-e2e: ## run tests quickly with the default Python
+e2e: ## run tests quickly with the default Python
 	playwright install --with-deps
 	pytest e2e --browser webkit --browser firefox --browser chromium  --numprocesses auto
-
-e2e: ## run e2e tests with playwright
-	tox
-
-test-all: ## run tests on every Python version with tox
-	tox
 
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source shiny -m pytest

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,6 +19,12 @@ The following commands can be run from the repo root:
 ```sh
 # Run all e2e tests
 make e2e
+
+# Run just the tests in e2e/async/
+make e2e FILE=e2e/async
+
+# Run just the tests in e2e/async/, in headed mode
+make e2e FILE="--headed e2e/async"
 ```
 
 ## Shiny app fixtures

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,14 +19,6 @@ The following commands can be run from the repo root:
 ```sh
 # Run all e2e tests
 make e2e
-# Another way to run all e2e tests
-tox
-
-# Run just the tests in e2e/async/
-tox e2e/async
-
-# Run just the tests in e2e/async/, in headed mode
-tox -- --headed e2e/async
 ```
 
 ## Shiny app fixtures

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,6 @@ dev =
     pyright>=1.1.244
     pre-commit>=2.15.0
     wheel
-    tox
     matplotlib
     pandas
     pandas-stubs
@@ -109,17 +108,6 @@ console_scripts =
 # W503: Line break occurred before a binary operator
 ignore = E302, E501, F403, F405, W503
 extend_exclude = docs, .venv, venv, typings, e2e, build
-
-[tox:tox]
-envlist = e2e
-
-[testenv:e2e]
-deps =
-    -r .github/requirements-tox.txt
-commands =
-    # We are currently ONLY using tox for running e2e tests.
-    playwright install --with-deps
-    pytest {posargs:e2e} --browser webkit --browser firefox --browser chromium --numprocesses auto
 
 [isort]
 profile=black


### PR DESCRIPTION
Fixes #417 

--------------------------------------------

`tox` was introduced to the repo in #320

A clear article on why `tox` is useful: https://christophergs.com/python/2020/04/12/python-tox-why-use-it-and-tutorial/
tl/dr 
> * Test against different versions of Python (which would have alerted Kyle that the library hadn’t been tested against his install version).
> * Test against different dependency versions
> * Capture and run setup steps/ad hoc commands (which Kyle could have made a mistake on / not known about)
> * Isolate environment variables - By design, tox does not pass any evars from the system. Instead you are asked to explicitly declare them (which would have alerted Kyle to any environment variable requirements).
> * Do all the above across Windows / macOS / Linux (which would have saved Kyle if the issue had been due to the OS)

---------------------------------------------

#417 requests that e2e tests use the locally installed packages.  By definition, this is impossible with `tox`.

`tox` cannot install a dependency from github unless it is in a requirements file. This file is not cached. It feels like a giant hack.

I believe the `tox` advantage is minimal as we:
* Are not testing against multiple python versions locally
* Have only a few extra dependencies for e2e testing
* Do not use Environment variables
* Have consistent scripts that can be run

Disadvantage of not using tox:
* Not being able to cleanly pass arguments into the pytest command. However, this can be done with environment variables
	* This can be mitigated by using an environment variable `FILE`. Ex, test the `e2e/outputs`: `make e2e FILE=e2e/outputs`