### PR TITLE
Raise warning if `reactive.Effect` function returns a value

### DIFF
--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -531,7 +531,16 @@ class Effect_:
         with session_context(self._session):
             try:
                 with ctx():
-                    await self._fn()
+                    res = await self._fn()
+
+                    if res is not None:
+                        warnings.warn(
+                            "reactive.Effect function returned a value, but should return None; "
+                            "reactive.Effects should only be used for side effects. "
+                            "Did you mean to use reactive.Calc instead?",
+                            ReactiveWarning,
+                            stacklevel=2,
+                        )
             except SilentException:
                 # It's OK for SilentException to cause an Effect to stop running
                 pass

--- a/tests/test_reactives.py
+++ b/tests/test_reactives.py
@@ -394,6 +394,27 @@ async def test_isolate_async_prevents_dependency():
 
 
 # ======================================================================
+# Effects warn if user function returns a value
+# ======================================================================
+@pytest.mark.asyncio
+async def test_effect_no_return_value():
+    # Should warn because of non-None return value
+    @Effect  # pyright: ignore[reportGeneralTypeIssues]
+    def o1():
+        return 1
+
+    with pytest.warns(ReactiveWarning):
+        await flush()
+
+    # Should not warn because of None return value
+    @Effect()  # pyright: ignore[reportGeneralTypeIssues]
+    def o2():
+        ...
+
+    await flush()
+
+
+# ======================================================================
 # Priority for effects
 # ======================================================================
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #425. 
If a user function passed to `reactive.Effect` returns a value, that is most likely a mistake. This PR causes Shiny to raise a warning in that case. For example:

```py
@reactive.Effect
def _():
    return 1
```