### PR TITLE
Allow for htmldeps with no source file location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Added support for URL based HTMLDependencies. `{htmltools}` (v0.1.5.9001) added support for URL based HTMLDependencies in rstudio/py-htmltools#53.  (#437)
 
 ### Bug fixes
 

--- a/shiny/__init__.py
+++ b/shiny/__init__.py
@@ -1,6 +1,6 @@
 """A package for building reactive web applications."""
 
-__version__ = "0.2.10.9000"
+__version__ = "0.2.10.9001"
 
 from ._shinyenv import is_pyodide as _is_pyodide
 

--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -338,14 +338,15 @@ class App:
         # (Some HTMLDependencies only carry head content, and have no source on disk.)
         if dep.source:
             paths = dep.source_path_map(lib_prefix=self.lib_prefix)
-            self._dependency_handler.routes.insert(
-                0,
-                starlette.routing.Mount(
-                    "/" + paths["href"],
-                    StaticFiles(directory=paths["source"]),
-                    name=dep.name + "-" + str(dep.version),
-                ),
-            )
+            if paths["source"] != "":
+                self._dependency_handler.routes.insert(
+                    0,
+                    starlette.routing.Mount(
+                        "/" + paths["href"],
+                        StaticFiles(directory=paths["source"]),
+                        name=dep.name + "-" + str(dep.version),
+                    ),
+                )
 
         self._registered_dependencies[dep.name] = dep
 


### PR DESCRIPTION
Related: `Add URL support to HTMLDependency` - https://github.com/rstudio/py-htmltools/pull/53