### PR TITLE
Update functions to use new htmltools whitespace behavior

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     contextvars>=2.4
     websockets>=10.0
     python-multipart
-    htmltools>=0.1.4.9001
+    htmltools>=0.1.4.9002
     click>=8.0.3
     markdown-it-py>=1.1.0
     # This is needed for markdown-it-py. Without it, when loading shiny/ui/_markdown.py,

--- a/shiny/ui/_input_check_radio.py
+++ b/shiny/ui/_input_check_radio.py
@@ -72,6 +72,7 @@ def input_checkbox(
                     type="checkbox",
                     checked="checked" if value else None,
                 ),
+                " ",
                 span(label),
             ),
             class_="checkbox",
@@ -138,6 +139,7 @@ def _input_checkbox(
                 type="checkbox",
                 checked="checked" if value else None,
             ),
+            " ",
             tags.label(label, class_="form-check-label", for_=resolve_id(id)),
             class_=class_,
         ),
@@ -333,9 +335,9 @@ def _generate_option(
         checked="checked" if checked else None,
     )
     if inline:
-        return tags.label(input, span(label), class_=type + "-inline")
+        return tags.label(input, " ", span(label), class_=type + "-inline")
     else:
-        return div(tags.label(input, span(label)), class_=type)
+        return div(tags.label(input, " ", span(label)), class_=type)
 
 
 def _normalize_choices(x: ChoicesArg) -> _Choices:


### PR DESCRIPTION
After https://github.com/rstudio/py-htmltools/pull/54 is merged, a few components need explicit whitespace.