### PR TITLE
Make random port test more robust

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ test =
     pytest-asyncio>=0.17.2
     pytest-playwright>=0.3.0
     pytest-xdist
+    pytest-timeout
     psutil
     astropy
     suntime

--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -89,7 +89,7 @@ class App:
     def __init__(
         self,
         ui: Tag | TagList | Callable[[Request], Tag | TagList],
-        server: Optional[Callable[[Inputs, Outputs, Session], None]] = None,
+        server: Optional[Callable[[Inputs, Outputs, Session], None]],
         *,
         static_assets: Optional["str" | "os.PathLike[str]"] = None,
         debug: bool = False,

--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -89,7 +89,7 @@ class App:
     def __init__(
         self,
         ui: Tag | TagList | Callable[[Request], Tag | TagList],
-        server: Optional[Callable[[Inputs, Outputs, Session], None]],
+        server: Optional[Callable[[Inputs, Outputs, Session], None]] = None,
         *,
         static_assets: Optional["str" | "os.PathLike[str]"] = None,
         debug: bool = False,

--- a/shiny/_utils.py
+++ b/shiny/_utils.py
@@ -102,7 +102,7 @@ def random_port(
     while n > 0:
         if (max - min + 1) <= len(unusable):
             break
-        port = round(random.random() * (max - min) + min)
+        port = random.randint(min, max)
         if port in unusable:
             continue
         try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -149,10 +149,9 @@ def test_random_port():
     n = 100
 
     # Find a range of `num_ports` ports that are all available
-    for i in range(n):
-        assert (
-            i < n - 1
-        ), f"Could not find {num_ports} continguous ports to use for testing"
+    attempts = 0
+    for _ in range(n):
+        attempts += 1
         j = 0
         try:
             for j in range(num_ports):
@@ -166,6 +165,12 @@ def test_random_port():
             # Shift the test range and try again
             port += j + 1
             print(port)
+    # If no port is available, throw an error
+    # `attempts` should be << n
+    if attempts == n:
+        raise RuntimeError(
+            f"Could not find {num_ports} continguous ports to use for testing in {n} tries"
+        )
 
     seen: Set[int] = set()
     # Ensure that `k` unique random ports are eventually generated. If not (e.g. if the

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -136,7 +136,7 @@ async def test_async_callbacks():
     assert cb4.exec_count == 1  # Registered during previous invoke(), was called
 
 
-# Timeout within 2 seconds (not)
+# Timeout within 2 seconds
 @pytest.mark.timeout(2)
 def test_random_port():
     assert random_port(9000, 9000) == 9000

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -143,17 +143,19 @@ def test_random_port():
 
     # Starting port
     port = 9001
-    # Test `k` continguous ports
-    k = 10
+    # Test a set of continguous ports
+    num_ports = 10
     # Number of times to try to find a port range
     n = 100
 
-    # Find a range of `k` ports that are all available
+    # Find a range of `num_ports` ports that are all available
     for i in range(n):
-        assert i < n - 1, f"Could not find {k} continguous ports to use for testing"
+        assert (
+            i < n - 1
+        ), f"Could not find {num_ports} continguous ports to use for testing"
         j = 0
         try:
-            for j in range(k):
+            for j in range(num_ports):
                 random_port(port + j, port + j)
             # If we reach this point, we have found a plausible range of ports to use
             break
@@ -169,11 +171,11 @@ def test_random_port():
     # Ensure that `k` unique random ports are eventually generated. If not (e.g. if the
     # max port number is treated as exclusive instead of inclusive, say) then the while
     # loop will not exit and the test will timeout.
-    max_port = port + k - 1
-    while len(seen) < k:
+    max_port = port + num_ports - 1
+    while len(seen) < num_ports:
         seen.add(random_port(port, max_port))
 
-    assert len(seen) == k
+    assert len(seen) == num_ports
 
 
 def test_random_port_unusable():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -173,7 +173,7 @@ def test_random_port():
         )
 
     seen: Set[int] = set()
-    # Ensure that `k` unique random ports are eventually generated. If not (e.g. if the
+    # Ensure that `num_ports` unique random ports are eventually generated. If not (e.g. if the
     # max port number is treated as exclusive instead of inclusive, say) then the while
     # loop will not exit and the test will timeout.
     max_port = port + num_ports - 1


### PR DESCRIPTION
Other changes
* Make random port test more robust. 
	* GitHub Desktop uses port `9010`
	* Set the timeout to 2s
	* If a port is busy, shift the testing port range
* Use `random.randint(min, max)` for uniform port
	* Rounding _technically_ isn't uniform. Using a single method is less complicated.