### PR TITLE
Independent of dependency version, serve it if requested

### DIFF
--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -334,8 +334,12 @@ class App:
         # the user is requesting THIS dependency. Therefore, it should be available to
         # the user independent of any previous versions of the dependency being served.
 
-        # Note: htmltools does do dependency de-duplication and finds the highest
-        # version to return. However, dynamic UI and callable UI do not run through the same filter over time. When using callable UI functions, UI dependencies are reset on refresh. So if a dependency makes it here, it is not necessarily the highest version served over time but is the highest version for this particular UI. Therefore, serve it must be served.
+        # Note: htmltools does de-duplicate dependencies and finds the highest version
+        # to return. However, dynamic UI and callable UI do not run through the same
+        # filter over time. When using callable UI functions, UI dependencies are reset
+        # on refresh. So if a dependency makes it here, it is not necessarily the
+        # highest version served over time but is the highest version for this
+        # particular UI. Therefore, serve it must be served.
         dep_name = html_dep_name(dep)
         if dep_name in self._registered_dependencies:
             return

--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -328,10 +328,16 @@ class App:
             self._register_web_dependency(dep)
 
     def _register_web_dependency(self, dep: HTMLDependency) -> None:
-        if (
-            dep.name in self._registered_dependencies
-            and dep.version >= self._registered_dependencies[dep.name].version
-        ):
+        # If the dependency has been seen before, quit early.
+
+        # Even if the htmldependency version is higher or lower, the HTML being sent to
+        # the user is requesting THIS dependency. Therefore, it should be available to
+        # the user independent of any previous versions of the dependency being served.
+
+        # Note: htmltools does do dependency de-duplication and finds the highest
+        # version to return. However, dynamic UI and callable UI do not run through the same filter over time. When using callable UI functions, UI dependencies are reset on refresh. So if a dependency makes it here, it is not necessarily the highest version served over time but is the highest version for this particular UI. Therefore, serve it must be served.
+        dep_name = html_dep_name(dep)
+        if dep_name in self._registered_dependencies:
             return
 
         # For HTMLDependencies that have sources on disk, mount the source dir.
@@ -344,11 +350,11 @@ class App:
                     starlette.routing.Mount(
                         "/" + paths["href"],
                         StaticFiles(directory=paths["source"]),
-                        name=dep.name + "-" + str(dep.version),
+                        name=dep_name,
                     ),
                 )
 
-        self._registered_dependencies[dep.name] = dep
+        self._registered_dependencies[dep_name] = dep
 
     def _render_page(self, ui: Tag | TagList, lib_prefix: str) -> RenderedHTML:
         ui_res = copy.copy(ui)
@@ -365,3 +371,7 @@ def is_uifunc(x: Tag | TagList | Callable[[Request], Tag | TagList]):
         return False
     else:
         return True
+
+
+def html_dep_name(dep: HTMLDependency) -> str:
+    return dep.name + "-" + str(dep.version)

--- a/tests/test_ui_dependencies.py
+++ b/tests/test_ui_dependencies.py
@@ -1,0 +1,47 @@
+import htmltools
+
+from shiny import App, ui
+from shiny._app import html_dep_name
+
+
+def test_duplicate_deps():
+    some_dep1 = htmltools.HTMLDependency(
+        "test_dep",
+        "1",
+        source={
+            "subdir": ".",
+        },
+        all_files=True,
+    )
+    some_dep2 = htmltools.HTMLDependency(
+        "test_dep",
+        "2",
+        source={
+            "subdir": ".",
+        },
+        all_files=True,
+    )
+    some_dep3 = htmltools.HTMLDependency(
+        "test_dep",
+        "3",
+        source={
+            "subdir": ".",
+        },
+        all_files=True,
+    )
+
+    # Put v1 at the end to make sure lower versions can be added
+    # Put v3 in the middle to make sure a higher version can be added
+    deps = [some_dep2, some_dep3, some_dep1]
+
+    app = App(ui.div("ui goes here"))
+
+    # During a page refresh, the same session is kept alive. This means the mapping of `app._registered_dependencies` is kept. However, the dependencies requested by the user can be different when using a UI function.
+
+    # Simulate adding the _conflicting_ dependencies from three different dynamic UI
+    # functions
+    for dep in deps:
+        app._register_web_dependency(dep)
+    # All three dependencies should be registered as they are unique and will be requested by the browser
+    for dep in deps:
+        assert html_dep_name(dep) in app._registered_dependencies

--- a/tests/test_ui_dependencies.py
+++ b/tests/test_ui_dependencies.py
@@ -34,7 +34,7 @@ def test_duplicate_deps():
     # Put v3 in the middle to make sure a higher version can be added
     deps = [some_dep2, some_dep3, some_dep1]
 
-    app = App(ui.div("ui goes here"))
+    app = App(ui.div("ui goes here"), server=None)
 
     # During a page refresh, the same session is kept alive. This means the mapping of `app._registered_dependencies` is kept. However, the dependencies requested by the user can be different when using a UI function.
 


### PR DESCRIPTION
Even if the htmldependency version is higher or lower, the HTML being sent to the user is requesting THIS dependency. Therefore, it should be available to the user independent of any previous versions of the dependency being served.

`{htmltools}` does de-duplicate dependencies and finds the highest version to return. However, dynamic UI and callable UI do not run through the same filter over time. When using callable UI functions, UI dependencies are reset
on refresh. So if a dependency makes it here, it is not necessarily the highest version served over time but is the highest version for this particular UI. Therefore, serve it must be served.