### PR TITLE
For streaming downloads, add `Transfer-Encoding: chunked` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Fixed #443: Errors in streaming downloads previously resulted in a partially downloaded file; now Shiny responds with a `Transfer-Encoding: chunked` header, which allows the browser to detect the error and abort the download. (#447)
 
 ### Other changes
 

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -516,6 +516,12 @@ class Session(object, metaclass=SessionMeta):
 
                             wrapped_contents = wrap_content_sync()
 
+                        # In streaming downloads, we send a 200 response, but if an
+                        # error occurs in the middle of it, the client needs to know.
+                        # With chunked encoding, the client will know if an error occurs
+                        # if it does not receive a terminating (empty) chunk.
+                        headers["Transfer-Encoding"] = "chunked"
+
                         return StreamingResponse(
                             wrapped_contents,
                             200,


### PR DESCRIPTION
Closes #443.

For streaming downloads, adding the header `Transfer-Encoding: chunked` lets the client know that it should keep receiving data until it gets a terminating chunk (with size zero). If the transfer ends before then, then the client knows there was an error.

https://stackoverflow.com/a/40282512/412655


Now with the download test app, an error in a streaming download results in this showing in Chrome:

<img width="232" alt="image" src="https://user-images.githubusercontent.com/86978/231044880-173f134c-8ecc-4f0b-ac1f-70aca9360d91.png">
