### PR TITLE
Use explicit `int64` when converting `datetime`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Fixed #456: plot interaction with datetimes raised errors on 32-bit platforms due. (#457)
+
 ### Other changes
 
 * When pyright creates type stubs for shiny, it now will include types imported in `_typing_extensions.py`.

--- a/shiny/plotutils.py
+++ b/shiny/plotutils.py
@@ -358,7 +358,7 @@ def to_float(x: DataFrameColumn) -> pd.Series[float]:
         return (
             cast(
                 "pd.Series[int]",
-                pd.Series(x.astype("int")),  # pyright: ignore
+                pd.Series(x.astype("int64")),  # pyright: ignore
             )
             / (24 * 60 * 60)
             / 1e9


### PR DESCRIPTION
This fixes #456.