### PR TITLE
chore: remove dead links from comments

### DIFF
--- a/shiny/examples/download_button/app.py
+++ b/shiny/examples/download_button/app.py
@@ -10,8 +10,6 @@ app_ui = ui.page_fluid(
 )
 
 
-# For more examples of different types of download handlers, see:
-# https://github.com/rstudio/py-shiny/blob/68ffc27/examples/download/app.py#L90
 def server(input: Inputs, output: Outputs, session: Session):
     @session.download(
         filename=lambda: f"新型-{date.today().isoformat()}-{np.random.randint(100,999)}.csv"

--- a/shiny/examples/download_link/app.py
+++ b/shiny/examples/download_link/app.py
@@ -10,8 +10,6 @@ app_ui = ui.page_fluid(
 )
 
 
-# For more examples of different types of download handlers, see:
-# https://github.com/rstudio/py-shiny/blob/68ffc27/examples/download/app.py#L90
 def server(input: Inputs, output: Outputs, session: Session):
     @session.download(
         filename=lambda: f"新型-{date.today().isoformat()}-{np.random.randint(100,999)}.csv"


### PR DESCRIPTION
I thought about updating the links but realised that the `py-shiny/shiny/examples/download/app.py` shows a full set of examples, and with `py-shiny/shiny/examples/download_button/app.py` and `py-shiny/shiny/examples/download_link/app.py` covering link and button specific examples, the comment was no longer necessary.

This addresses issue https://github.com/rstudio/py-shiny/issues/555