### PR TITLE
fix(x.ui.accordion): Rename `accordion_panel_update()` to `update_accordion_panel()`

### DIFF
--- a/shiny/experimental/e2e/accordion/app.py
+++ b/shiny/experimental/e2e/accordion/app.py
@@ -95,7 +95,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
 
         nonlocal has_updates
         if has_updates:
-            x.ui.accordion_panel_update(
+            x.ui.update_accordion_panel(
                 "acc",
                 "updated_section_a",
                 "Some narrative for section A",
@@ -109,7 +109,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
                 if "Section A" not in acc():
                     ui.notification_show("Opening Section A", duration=2)
                     x.ui.accordion_panel_open("acc", "Section A")
-            x.ui.accordion_panel_update(
+            x.ui.update_accordion_panel(
                 "acc",
                 "Section A",
                 "Updated body",

--- a/shiny/experimental/examples/accordion_panel_update/app.py
+++ b/shiny/experimental/examples/accordion_panel_update/app.py
@@ -26,7 +26,7 @@ def server(input: Inputs, output: Outputs, session: Session):
     def _():
         txt = " (updated)" if input.update_panel() else ""
         for letter in "ABCDE":
-            x.ui.accordion_panel_update(
+            x.ui.update_accordion_panel(
                 "acc",
                 f"sec_{letter}",
                 f"Some{txt} narrative for section {letter}",

--- a/shiny/experimental/ui/__init__.py
+++ b/shiny/experimental/ui/__init__.py
@@ -41,7 +41,7 @@ from ._accordion import (
     accordion_panel_close,
     accordion_panel_insert,
     accordion_panel_remove,
-    accordion_panel_update,
+    update_accordion_panel,
 )
 
 
@@ -98,5 +98,5 @@ __all__ = (
     "accordion_panel_close",
     "accordion_panel_insert",
     "accordion_panel_remove",
-    "accordion_panel_update",
+    "update_accordion_panel",
 )

--- a/shiny/experimental/ui/_accordion.py
+++ b/shiny/experimental/ui/_accordion.py
@@ -21,7 +21,7 @@ __all__ = (
     "accordion_panel_open",
     "accordion_panel_remove",
     "accordion_panel_set",
-    "accordion_panel_update",
+    "update_accordion_panel",
 )
 
 
@@ -75,7 +75,7 @@ class AccordionPanel:
                 "aria-controls": self._id,
             },
             btn_attrs,
-            # Always include an .accordion-icon container to simplify accordion_panel_update() logic
+            # Always include an .accordion-icon container to simplify update_accordion_panel() logic
             tags.div({"class": "accordion-icon"}, self._icon),
             tags.div({"class": "accordion-title"}, self._title),
         )
@@ -166,7 +166,7 @@ def accordion(
     * :func:`~shiny.experimental.ui.accordion_panel_close`
     * :func:`~shiny.experimental.ui.accordion_panel_insert`
     * :func:`~shiny.experimental.ui.accordion_panel_remove`
-    * :func:`~shiny.experimental.ui.accordion_panel_update`
+    * :func:`~shiny.experimental.ui.update_accordion_panel`
     """
 
     # TODO-bookmarking: Restore input here
@@ -274,7 +274,7 @@ def accordion_panel(
     * :func:`~shiny.experimental.ui.accordion_panel_close`
     * :func:`~shiny.experimental.ui.accordion_panel_insert`
     * :func:`~shiny.experimental.ui.accordion_panel_remove`
-    * :func:`~shiny.experimental.ui.accordion_panel_update`
+    * :func:`~shiny.experimental.ui.update_accordion_panel`
     """
 
     if value is MISSING:
@@ -367,7 +367,7 @@ def accordion_panel_set(
     * :func:`~shiny.experimental.ui.accordion_panel_close`
     * :func:`~shiny.experimental.ui.accordion_panel_insert`
     * :func:`~shiny.experimental.ui.accordion_panel_remove`
-    * :func:`~shiny.experimental.ui.accordion_panel_update`
+    * :func:`~shiny.experimental.ui.update_accordion_panel`
     """
     _accordion_panel_action(id=id, method="set", values=values, session=session)
 
@@ -404,7 +404,7 @@ def accordion_panel_open(
     * :func:`~shiny.experimental.ui.accordion_panel_close`
     * :func:`~shiny.experimental.ui.accordion_panel_insert`
     * :func:`~shiny.experimental.ui.accordion_panel_remove`
-    * :func:`~shiny.experimental.ui.accordion_panel_update`
+    * :func:`~shiny.experimental.ui.update_accordion_panel`
     """
     _accordion_panel_action(id=id, method="open", values=values, session=session)
 
@@ -441,7 +441,7 @@ def accordion_panel_close(
     * :func:`~shiny.experimental.ui.accordion_panel_open`
     * :func:`~shiny.experimental.ui.accordion_panel_insert`
     * :func:`~shiny.experimental.ui.accordion_panel_remove`
-    * :func:`~shiny.experimental.ui.accordion_panel_update`
+    * :func:`~shiny.experimental.ui.update_accordion_panel`
     """
     _accordion_panel_action(id=id, method="close", values=values, session=session)
 
@@ -484,7 +484,7 @@ def accordion_panel_insert(
     * :func:`~shiny.experimental.ui.accordion_panel_open`
     * :func:`~shiny.experimental.ui.accordion_panel_close`
     * :func:`~shiny.experimental.ui.accordion_panel_remove`
-    * :func:`~shiny.experimental.ui.accordion_panel_update`
+    * :func:`~shiny.experimental.ui.update_accordion_panel`
     """
 
     if position not in ("after", "before"):
@@ -530,7 +530,7 @@ def accordion_panel_remove(
     * :func:`~shiny.experimental.ui.accordion_panel_open`
     * :func:`~shiny.experimental.ui.accordion_panel_close`
     * :func:`~shiny.experimental.ui.accordion_panel_insert`
-    * :func:`~shiny.experimental.ui.accordion_panel_update`
+    * :func:`~shiny.experimental.ui.update_accordion_panel`
     """
     if not isinstance(target, list):
         target = [target]
@@ -555,7 +555,7 @@ def _missing_none_x(x: T | None | MISSING_TYPE) -> T | Literal[""] | None:
 
 
 # TODO-maindocs; @add_example()
-def accordion_panel_update(
+def update_accordion_panel(
     id: str,
     target: str,
     *body: TagChild,


### PR DESCRIPTION
Matches ui function names using `update_*()` style