### PR TITLE
Use wrapping form of `as_fill_item()` in penguins app

### DIFF
--- a/examples/penguins/app.py
+++ b/examples/penguins/app.py
@@ -89,10 +89,11 @@ def server(input: Inputs, output: Outputs, session: Session):
                 title,
                 count,
                 {"class": "pt-1 pb-0"},
-                showcase=ui.tags.img(
-                    x.ui.as_fill_item(),
-                    {"style": "object-fit:contain;"},
-                    src=showcase_img,
+                showcase=x.ui.as_fill_item(
+                    ui.tags.img(
+                        {"style": "object-fit:contain;"},
+                        src=showcase_img,
+                    )
                 ),
                 theme_color=None,
                 style=f"background-color: {bgcol};",

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ dev =
     pandas
     pandas-stubs
     numpy
-    shinyswatch>=0.2.3
+    shinyswatch>=0.2.4
 
 [options.packages.find]
 include = shiny, shiny.*


### PR DESCRIPTION
Note that the value boxes still are laid out vertically instead of horizontally. That still needs to be fixed.

<img width="1133" alt="image" src="https://github.com/rstudio/py-shiny/assets/86978/973ef1f6-0c89-4761-b944-d495c3332879">
