### PR TITLE
Update manifest to bundle built JS for tanstack table

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Install node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: "18"
           cache: npm
           cache-dependency-path: examples/brownian/shinymediapipe/package-lock.json
       - name: Install node.js package
@@ -111,7 +111,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,test]"
+          pip install ".[dev,test]"
       - name: "Build Package"
         run: |
           make dist

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -111,7 +111,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ".[dev,test]"
+          make install-deps
+          make install
       - name: "Build Package"
         run: |
           make dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 recursive-include shiny/www *
 recursive-include shiny/experimental/www *
 recursive-include shiny/examples *
+recursive-include shiny/ui/dataframe/js/dist *

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ install: dist
 	python3 -m pip install dist/shiny*.whl
 
 install-deps: ## install dependencies
-	pip install ".[dev,test]"
+	pip install -e ".[dev,test]"
 
 # ## If caching is ever used, we could run:
 # install-deps: ## install latest dependencies

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ install: dist
 	python3 -m pip install dist/shiny*.whl
 
 install-deps: ## install dependencies
-	pip install -e ".[dev,test]"
+	pip install ".[dev,test]"
 
 # ## If caching is ever used, we could run:
 # install-deps: ## install latest dependencies


### PR DESCRIPTION
Without this, the data frame feature only works when you `pip install -e`, not a regular pip install, because the JS assets are not included in the source package.

Also update Makefile/CI so we catch this with automated tests in the future.