### PR TITLE
fix: drop contextvars from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     typing-extensions>=4.0.1
     uvicorn>=0.16.0
     starlette>=0.17.1
-    contextvars>=2.4
     websockets>=10.0
     python-multipart
     htmltools>=0.2.1


### PR DESCRIPTION
Closes #593 

`contextvars` has been in the standard library since python 3.7. We should remove it from setup.cfg so that pip doesn't try to install the [backport](https://pypi.org/project/contextvars/).