### PR TITLE
feat(cli): add short aliases to shiny run args

### DIFF
--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -47,6 +47,7 @@ any of the following will work:
 )
 @click.argument("app", default="app.py:app")
 @click.option(
+    "-h",
     "--host",
     type=str,
     default="127.0.0.1",
@@ -54,6 +55,7 @@ any of the following will work:
     show_default=True,
 )
 @click.option(
+    "-p",
     "--port",
     type=int,
     default=8000,
@@ -68,6 +70,7 @@ any of the following will work:
     show_default=True,
 )
 @click.option(
+    "-r",
     "--reload",
     is_flag=True,
     default=False,
@@ -88,6 +91,7 @@ any of the following will work:
     show_default=True,
 )
 @click.option(
+    "-d",
     "--app-dir",
     default=".",
     show_default=True,
@@ -103,6 +107,7 @@ any of the following will work:
     show_default=True,
 )
 @click.option(
+    "-b",
     "--launch-browser",
     is_flag=True,
     default=False,


### PR DESCRIPTION
I like running with `shiny run --reload --launch-browser` but it's taken me a long time to remember the spelling of those options. But `shiny run -rb` is much easier for me to remember and type.

I didn't add aliases for everything, only the more obvious ones.