### PR TITLE
Remove contextvars dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     typing-extensions>=4.0.1
     uvicorn>=0.16.0
     starlette>=0.17.1
-    contextvars>=2.4
     websockets>=10.0
     python-multipart
     htmltools>=0.2.1


### PR DESCRIPTION
Per @nealrichardson comment in #593, this was only needed for Python 3.7, which we no longer support.