### PR TITLE
Make --app-path work with app file argument

### DIFF
--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -360,18 +360,20 @@ def resolve_app(app: str, app_dir: Optional[str]) -> tuple[str, Optional[str]]:
         attr = "app"
 
     if is_file(module):
+        # Before checking module path, resolve it relative to app_dir if provided
+        module_path = module if app_dir is None else os.path.join(app_dir, module)
         # TODO: We should probably be using some kind of loader
         # TODO: I don't like that we exit here, if we ever export this it would be bad;
         #       but also printing a massive stack trace for a `shiny run badpath` is way
         #       unfriendly. We should probably throw a custom error that the shiny run
         #       entrypoint knows not to print the stack trace for.
-        if not os.path.exists(module):
-            sys.stderr.write(f"Error: {module} not found\n")
+        if not os.path.exists(module_path):
+            sys.stderr.write(f"Error: {module_path} not found\n")
             sys.exit(1)
-        if not os.path.isfile(module):
-            sys.stderr.write(f"Error: {module} is not a file\n")
+        if not os.path.isfile(module_path):
+            sys.stderr.write(f"Error: {module_path} is not a file\n")
             sys.exit(1)
-        dirname, filename = os.path.split(module)
+        dirname, filename = os.path.split(module_path)
         module = filename[:-3] if filename.endswith(".py") else filename
         app_dir = dirname
 


### PR DESCRIPTION
Without this, `shiny run --app-dir=foo app.py` won't work even if foo/app.py exists and is a valid Shiny app. This is because the code that turns `app.py` into `app:app` for Uvicorn wasn't aware of --app-dir.