### PR TITLE
bug(typing): Fix typing issues in latest `click` package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     websockets>=10.0
     python-multipart
     htmltools>=0.2.1
-    click>=8.0.3
+    click>=8.1.4
     markdown-it-py>=1.1.0
     # This is needed for markdown-it-py. Without it, when loading shiny/ui/_markdown.py,
     # Python emits the following: "UserWarning: The 'tasklists' feature of GitHub

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -10,7 +10,7 @@ import shutil
 import sys
 import types
 from pathlib import Path
-from typing import Any, NotRequired, Optional, TypedDict
+from typing import Any, Optional
 
 import click
 import uvicorn
@@ -19,6 +19,7 @@ import uvicorn.config
 import shiny
 
 from . import _autoreload, _hostenv, _static, _utils
+from ._typing_extensions import NotRequired, TypedDict
 
 
 @click.group("main")

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -21,7 +21,7 @@ import shiny
 from . import _autoreload, _hostenv, _static, _utils
 
 
-@click.group()  # pyright: ignore[reportUnknownMemberType]
+@click.group("main")
 def main() -> None:
     pass
 
@@ -253,7 +253,7 @@ def run_app(
     maybe_setup_rsw_proxying(log_config)
 
     uvicorn.run(  # pyright: ignore[reportUnknownMemberType]
-        app,  # pyright: ignore[reportGeneralTypeIssues]
+        app,
         host=host,
         port=port,
         ws_max_size=ws_max_size,

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -10,7 +10,7 @@ import shutil
 import sys
 import types
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, NotRequired, Optional, TypedDict
 
 import click
 import uvicorn
@@ -233,7 +233,7 @@ def run_app(
         else:
             setup_hot_reload(log_config, autoreload_port, port, launch_browser)
 
-    reload_args: dict[str, bool | str | list[str]] = {}
+    reload_args: ReloadArgs = {}
     if reload:
         reload_dirs = []
         if app_dir is not None:
@@ -446,3 +446,9 @@ def static_assets(command: str) -> None:
         _static.print_shinylive_local_info()
     else:
         raise click.UsageError(f"Unknown command: {command}")
+
+
+class ReloadArgs(TypedDict):
+    reload: NotRequired[bool]
+    reload_includes: NotRequired[list[str]]
+    reload_dirs: NotRequired[list[str]]

--- a/shiny/_typing_extensions.py
+++ b/shiny/_typing_extensions.py
@@ -2,6 +2,15 @@
 # flake8: noqa: F401
 # pyright: reportUnusedImport=false
 
+__all__ = (
+    "Concatenate",
+    "ParamSpec",
+    "TypeGuard",
+    "NotRequired",
+    "TypedDict",
+    "assert_type",
+)
+
 
 import sys
 
@@ -17,10 +26,3 @@ if sys.version_info >= (3, 11):
     from typing import NotRequired, TypedDict, assert_type
 else:
     from typing_extensions import NotRequired, TypedDict, assert_type
-
-
-# The only purpose of the following line is so that pyright will put all of the
-# conditional imports into the .pyi file when generating type stubs. Without this line,
-# pyright will not include the above imports in the generated .pyi file, and it will
-# result in a lot of red squiggles in user code.
-_: 'Concatenate[str, ParamSpec("P")] | ParamSpec | TypeGuard | NotRequired | TypedDict | assert_type'  # type:ignore


### PR DESCRIPTION
@jcheng5 My questionable change is adding the name to `click.group()`. Is this an ok change?

-----------------------

```
pyright
/home/runner/work/py-shiny/py-shiny/shiny/_main.py
  /home/runner/work/py-shiny/py-shiny/shiny/_main.py:24:2 - error: Untyped function decorator obscures type of function; ignoring decorator (reportUntypedFunctionDecorator)
  /home/runner/work/py-shiny/py-shiny/shiny/_main.py:32:7 - error: Cannot access member "command" for type "function"
    Member "command" is unknown (reportFunctionMemberAccess)
  /home/runner/work/py-shiny/py-shiny/shiny/_main.py:370:7 - error: Cannot access member "command" for type "function"
    Member "command" is unknown (reportFunctionMemberAccess)
  /home/runner/work/py-shiny/py-shiny/shiny/_main.py:399:7 - error: Cannot access member "command" for type "function"
    Member "command" is unknown (reportFunctionMemberAccess)
  /home/runner/work/py-shiny/py-shiny/shiny/_main.py:427:7 - error: Cannot access member "command" for type "function"
    Member "command" is unknown (reportFunctionMemberAccess)
5 errors, 0 warnings, 0 informations
```

cc @karangattu 