### PR TITLE
Leverage `rows` to update height, not style's `height` value

### DIFF
--- a/shiny/experimental/www/textarea-autoresize.js
+++ b/shiny/experimental/www/textarea-autoresize.js
@@ -9,8 +9,15 @@
 
   onDelegatedEvent("input", "textarea.textarea-autoresize", (e) => {
     const { target } = e;
-    // Automatically resize the textarea to fit its content.
-    target.style.height = "auto";
-    target.style.height = target.scrollHeight + "px";
+
+    // Removed lines!
+    // This may remove 1 too many lines. (Which will be added back in the next loop)
+    while (target.rows > 1 && target.scrollHeight === target.clientHeight) {
+      target.rows -= 1;
+    }
+    // Added lines!
+    while (target.scrollHeight > target.clientHeight) {
+      target.rows += 1;
+    }
   });
 })();


### PR DESCRIPTION
Request from @karangattu 

Knowing how many rows exist in the dom structure is much easier to test than setting the height value.

This approach trims lines then adds lines until the scroll height is the client height