### PR TITLE
Silence figure layout warning on matplotlib 3.7.2

### DIFF
--- a/examples/penguins/app.py
+++ b/examples/penguins/app.py
@@ -14,7 +14,7 @@ from colors import bg_palette, palette
 import shiny.experimental as x
 from shiny import App, Inputs, Outputs, Session, reactive, render, req, ui
 
-# There is a matplotlib bug which causes pyright failures
+# There is a matplotlib bug which causes CI failures
 # see https://github.com/rstudio/py-shiny/issues/611#issuecomment-1632866419
 if matplotlib.__version__ == "3.7.2":
     warnings.filterwarnings(

--- a/examples/penguins/app.py
+++ b/examples/penguins/app.py
@@ -1,9 +1,11 @@
 # TODO-future: Add filter of X varaible to reduce the data? (Here we would show "Gentoo" has count 0, rather than remove if no data exists)
 # TODO-future: Add brushing to zoom into the plot. The counts should represent the data in the zoomed area. (Single click would zoom out)
 
+import warnings
 from pathlib import Path
 from typing import List
 
+import matplotlib
 import pandas as pd
 import seaborn as sns
 import shinyswatch
@@ -11,6 +13,13 @@ from colors import bg_palette, palette
 
 import shiny.experimental as x
 from shiny import App, Inputs, Outputs, Session, reactive, render, req, ui
+
+# There is a matplotlib bug which causes pyright failures
+# see https://github.com/rstudio/py-shiny/issues/611#issuecomment-1632866419
+if matplotlib.__version__ == "3.7.2":
+    warnings.filterwarnings(
+        "ignore", category=UserWarning, message="The figure layout has changed to tight"
+    )
 
 sns.set_theme()
 


### PR DESCRIPTION
It seems like there's a matplotlib regression which causes our CI to fail [Issue #611](https://github.com/rstudio/py-shiny/issues/611). Since I was trying to debug this issue on another branch I went ahead and silenced that warning on the penguins app.