### PR TITLE
Fix example code blocks

### DIFF
--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -53,16 +53,17 @@ class App:
     Example
     -------
 
-    .. code-block:: python
+    ```{python}
+    #| eval: false
+    from shiny import  App, Inputs, Outputs, Session, ui
 
-        from shiny import  App, Inputs, Outputs, Session, ui
+    app_ui = ui.page_fluid("Hello Shiny!")
 
-        app_ui = ui.page_fluid("Hello Shiny!")
+    def server(input: Inputs, output: Outputs, session: Session):
+        pass
 
-        def server(input: Inputs, output: Outputs, session: Session):
-            pass
-
-        app = App(app_ui, server)
+    app = App(app_ui, server)
+    ```
     """
 
     lib_prefix: str = "lib/"

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -207,21 +207,21 @@ def run_app(
     Examples
     --------
 
-    .. code-block:: python
+    ```{python}
+    from shiny import run_app
 
-        from shiny import run_app
+    # Run ``app`` inside ``./app.py``
+    run_app()
 
-        # Run ``app`` inside ``./app.py``
-        run_app()
+    # Run ``app`` inside ``./myapp.py`` (or ``./myapp/app.py``)
+    run_app("myapp")
 
-        # Run ``app`` inside ``./myapp.py`` (or ``./myapp/app.py``)
-        run_app("myapp")
+    # Run ``my_app`` inside ``./myapp.py`` (or ``./myapp/app.py``)
+    run_app("myapp:my_app")
 
-        # Run ``my_app`` inside ``./myapp.py`` (or ``./myapp/app.py``)
-        run_app("myapp:my_app")
-
-        # Run ``my_app`` inside ``../myapp.py`` (or ``../myapp/app.py``)
-        run_app("myapp:my_app", app_dir="..")
+    # Run ``my_app`` inside ``../myapp.py`` (or ``../myapp/app.py``)
+    run_app("myapp:my_app", app_dir="..")
+    ```
     """
 
     # If port is 0, randomize

--- a/shiny/input_handler.py
+++ b/shiny/input_handler.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict
 if TYPE_CHECKING:
     from .session import Session
 
-
 from .types import ActionButtonValue
 
 InputHandlerType = Callable[[Any, str, "Session"], Any]
@@ -74,21 +73,23 @@ recommend the format of "packageName.widgetName").
 
 Example
 -------
-.. code-block:: python
-
-    from shiny.input_handler import input_handlers
-    @input_handlers.add("mypackage.intify")
-    def _(value, name, session):
-        return int(value)
+```{python}
+#| eval: false
+from shiny.input_handler import input_handlers
+@input_handlers.add("mypackage.intify")
+def _(value, name, session):
+    return int(value)
+```
 
 On the Javascript side, the associated input binding must have a corresponding
 ``getType`` method:
 
-.. code-block:: javascript
-
-    getType: function(el) {
-      return "mypackage.intify";
-    }
+```{python}
+#| eval: false
+getType: function(el) {
+    return "mypackage.intify";
+}
+```
 """
 
 

--- a/shiny/ui/_include_helpers.py
+++ b/shiny/ui/_include_helpers.py
@@ -63,16 +63,17 @@ def include_js(
     document, you can wrap it in ``head_content`` (in this case, just make sure you're
     aware that the DOM probably won't be ready when the script is executed).
 
-    .. code-block:: python
+    ```{python}
+    #| eval: false
+    ui.page_fluid(
+        ui.head_content(ui.include_js("custom.js")),
+    )
 
-        ui.fluidPage(
-            head_content(ui.include_js("custom.js")),
-        )
-
-        # Alternately you can inline Javscript by changing the method.
-        ui.fluidPage(
-            head_content(ui.include_js("custom.js", method = "inline")),
-        )
+    # Alternately you can inline Javscript by changing the method.
+    ui.page_fluid(
+        ui.head_content(ui.include_js("custom.js", method = "inline")),
+    )
+    ```
 
     See Also
     --------
@@ -133,19 +134,21 @@ def include_css(
     may result in a Flash of Unstyled Content (FOUC). To instead place the CSS in the
     :func:`~ui.tags.head` of the document, you can wrap it in ``head_content``:
 
-    .. code-block:: python
+    ```{python}
+    #| eval: false
+    from htmltools import head_content
+    from shiny import ui
 
-        from htmltools import head_content from shiny import ui
+    ui.page_fluid(
+        ui.head_content(ui.include_css("custom.css")),
 
-        ui.fluidPage(
-            head_content(ui.include_css("custom.css")),
-
-            # You can also inline css by passing a dictionary with a `style` element.
-            ui.div(
-                {"style": "font-weight: bold;"},
-                ui.p("Some text!"),
-            )
+        # You can also inline css by passing a dictionary with a `style` element.
+        ui.div(
+            {"style": "font-weight: bold;"},
+            ui.p("Some text!"),
         )
+    )
+    ```
 
     See Also
     --------


### PR DESCRIPTION
Code blocks with `.. code-block:: python` currently render like this with Quarto and Quartodoc:

![image (22)](https://github.com/rstudio/py-shiny/assets/86978/c823f8a5-1a5b-4684-a3c5-e147c5f54fb1)

This PR converts them to Quarto-style code blocks as described here: https://machow.github.io/quartodoc/get-started/docstring-examples.html#examples-using-code-blocks