### PR TITLE
Add a triage label to issues created by non-maintainers

### DIFF
--- a/.github/workflows/triage-issues.yaml
+++ b/.github/workflows/triage-issues.yaml
@@ -1,0 +1,29 @@
+name: Issue Management
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage_or_add_to_project:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if the issue creator is a maintainer
+        id: check_maintainer
+        run: |
+            echo "::set-output name=is_maintainer::$(curl -s -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.issue.user.login }}/permission \
+            | jq -r '.permission' | grep -q 'admin' && echo 'true' || echo 'false')"
+
+      - name: Apply "needs triage" label to issues created by non-maintainers
+        if: steps.check_maintainer.outputs.is_maintainer == 'false'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["needs-triage"]
+            })

--- a/.github/workflows/triage-issues.yaml
+++ b/.github/workflows/triage-issues.yaml
@@ -12,9 +12,8 @@ jobs:
       - name: Check if the issue creator is a maintainer
         id: check_maintainer
         run: |
-            echo "::set-output name=is_maintainer::$(curl -s -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
-            https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.issue.user.login }}/permission \
-            | jq -r '.permission' | grep -q 'admin' && echo 'true' || echo 'false')"
+            IS_ADMIN=`gh api /repos/rstudio/py-shiny/collaborators/${{ github.event.issue.user.login }}/permission --jq='.user.permissions.admin'`
+            echo "is_maintainer=$IS_ADMIN" >> "$GITHUB_OUTPUT"
 
       - name: Apply "needs triage" label to issues created by non-maintainers
         if: steps.check_maintainer.outputs.is_maintainer == 'false'

--- a/.github/workflows/triage-issues.yaml
+++ b/.github/workflows/triage-issues.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   triage_or_add_to_project:
     runs-on: ubuntu-latest
+    
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Check if the issue creator is a maintainer
@@ -17,12 +20,5 @@ jobs:
 
       - name: Apply "needs triage" label to issues created by non-maintainers
         if: steps.check_maintainer.outputs.is_maintainer == 'false'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ["needs-triage"]
-            })
+        run: |
+          gh issue edit ${{ github.event.number }} --add-label "needs-triage" --repo ${{ github.repository }}


### PR DESCRIPTION
The goal of this PR is to do the following:

- All issues from team members get immediately added to the project board
- All issues from the community get labelled with a "needs-triage" label so that we can respond to them more promptly

On the project board I've set up a job which pulls in all tickets without a "needs-triage" label.