### PR TITLE
Make model score app work on Connect/Shinyapps.io

### DIFF
--- a/examples/model-score/scoredata.py
+++ b/examples/model-score/scoredata.py
@@ -55,4 +55,16 @@ async def update_db(position):
 
 def begin():
     position = init_db()
-    asyncio.create_task(update_db(position))
+
+    # After initializing the database, we need to start a non-blocking task to update it
+    # every second or so. If an event loop is already running, we can use an asyncio
+    # task. (This is the case when running via `shiny run` and shinylive.) Otherwise, we
+    # need to launch a background thread and run an asyncio event loop there. (This is
+    # the case when running via shinyapps.io or Posit Connect.)
+
+    if asyncio.get_event_loop().is_running():
+        asyncio.create_task(update_db(position))
+    else:
+        from threading import Thread
+
+        Thread(target=lambda: asyncio.run(update_db(position)), daemon=True).start()


### PR DESCRIPTION
The `scoredata.begin()` function gets called from the top-level of app.py, that is, at module load time. When I was testing this locally and in shinylive, it was fine to use `asyncio.create_task()` here, because an asyncio event loop was already started courtesy of uvicorn by the time the app module is imported. But in Connect, the app module is imported way earlier, because Connect has ASGI middleware it needs to install around it. In that case, no asyncio event loop exists and we have to do something else.

I guess another way to do this would've been to use a one-shot reactive Effect at the top level. Seems like a weird pattern to promote.

Another would be to introduce start/stop callbacks on the App object. Or `app.starlette_app.add_event_handler("startup", scoredata.begin)` works already, but `starlette_app` is not a documented attribute on App.