### PR TITLE
Make flaky dataframe test have larger timeout

### DIFF
--- a/e2e/data_frame/test_data_frame.py
+++ b/e2e/data_frame/test_data_frame.py
@@ -130,9 +130,19 @@ def test_sort(
     select_dataset.set("diamonds")
     select_dataset.expect.to_have_value("diamonds")
 
-    # Test sorting
+    # Table cell locators
     header_clarity = grid_container.locator("tr:first-child th:nth-child(4)")
     first_cell_clarity = grid_container.locator("tr:first-child td:nth-child(4)")
+
+    # Test that the table contents have updated
+    # This may timeout unless a larger timeout is given
+    expect(header_clarity).not_to_have_text(
+        "num2",
+        timeout=15 * 1000,  # Larger timeout for CI
+    )
+    expect(first_cell_clarity).not_to_have_text("4")
+
+    # Test sorting
     expect(first_cell_clarity).to_have_text("SI2")
     header_clarity.click()
     expect(first_cell_clarity).to_have_text("I1")


### PR DESCRIPTION
I've ran into 5+ situations where this test has failed in other (unrelated) PRs. 

The root cause is the diamonds table take an extra second to load. This may time out on CI, but will pass locally. By changing the test and increasing the timeout, it should be clearer if the test fails and should occur less often (hopefully never due to timing).

cc @jcheng5 